### PR TITLE
chore: PR 자동 생성 기능 추가

### DIFF
--- a/.agt/agt.sh
+++ b/.agt/agt.sh
@@ -16,6 +16,43 @@ check_gh_cli() {
     fi
 }
 
+# 도움말 출력 함수
+print_help() {
+    echo "AGT - Automatic Git & Github Tool"
+    echo
+    echo "Usage: agt <command>"
+    echo
+    echo "Available Commands:"
+    echo "  list     List all open issues in current repository, sorted by issue number"
+    echo "  branch   Create and switch to a new feature branch based on issue number"
+    echo "           Format: feature-{fe|be}-#{issue-number}"
+    echo "  pr       Create a pull request from current feature branch"
+    echo
+    echo "Command Details:"
+    echo "  list:"
+    echo "    - Shows all open issues in the current repository"
+    echo "    - Issues are sorted by number"
+    echo "    - No additional arguments required"
+    echo
+    echo "  branch:"
+    echo "    - Shows list of open issues and prompts for issue number"
+    echo "    - Creates a new branch from dev-fe or dev-be based on issue prefix"
+    echo "    - Automatically switches to the new branch"
+    echo "    - Branch naming convention: feature-fe-#1 or feature-be-#1"
+    echo
+    echo "  pr:"
+    echo "    - Creates a pull request from current feature branch"
+    echo "    - PR title will match the issue title"
+    echo "    - Adds reviewers from CODEOWNERS automatically"
+    echo "    - Uses pull request template from .github/pull_request_template.md"
+    echo "    - Automatically links PR with issue for auto-close on merge"
+    echo
+    echo "Examples:"
+    echo "  agt list"
+    echo "  agt branch"
+    echo "  agt pr"
+}
+
 # 이슈 목록 출력 함수
 list_issues() {
     check_git_repo
@@ -30,7 +67,7 @@ list_issues() {
     done
 }
 
-# 브랜치 생성 함수는 이전과 동일...
+# 브랜치 생성 함수
 create_branch() {
     check_git_repo
     check_gh_cli
@@ -85,6 +122,66 @@ create_branch() {
     echo "Successfully created and switched to branch: $branch_name"
 }
 
+# PR 생성 함수
+create_pr() {
+    check_git_repo
+    check_gh_cli
+    
+    # 현재 브랜치 확인
+    current_branch=$(git branch --show-current)
+    
+    # feature 브랜치가 아닌 경우 종료
+    if [[ ! $current_branch =~ ^feature-(fe|be)-#[0-9]+$ ]]; then
+        echo "Error: Current branch is not a feature branch"
+        exit 1
+    }
+    
+    # 브랜치 정보에서 이슈 번호와 타입 추출
+    issue_number=$(echo $current_branch | sed 's/.*#\([0-9]\+\)$/\1/')
+    branch_type=$(echo $current_branch | sed 's/feature-\(fe\|be\).*/\1/')
+    
+    # 이슈 제목 가져오기
+    issue_title=$(gh issue view $issue_number --json title -q .title)
+    
+    # base 브랜치 결정
+    base_branch="dev-$branch_type"
+    
+    # CODEOWNERS 파일에서 리뷰어 목록 가져오기
+    reviewers=$(gh api /repos/:owner/:repo/contents/.github/CODEOWNERS --jq '.content' | 
+                base64 -d | 
+                grep -v '^#' | 
+                grep -o '@[[:alnum:]-]\+' | 
+                tr '\n' ',' | 
+                sed "s/@$(gh api /user --jq '.login'),//g" | 
+                sed 's/,$//')
+    
+    # PR 템플릿 읽기 및 수정
+    template_content=$(gh api /repos/:owner/:repo/contents/.github/pull_request_template.md --jq '.content' | base64 -d)
+    
+    # 이슈 번호 자동 추가
+    pr_body=$(echo "$template_content" | sed "s/## #️⃣ 이슈 번호/## #️⃣ 이슈 번호\n#$issue_number/")
+    
+    # PR 생성
+    echo "Creating PR with title: $issue_title"
+    echo "Base branch: $base_branch"
+    echo "Reviewers: $reviewers"
+    
+    # 변경사항 푸시
+    git push origin $current_branch
+    
+    # PR 생성
+    gh pr create \
+        --title "$issue_title" \
+        --body "$pr_body" \
+        --base "$base_branch" \
+        --reviewer "$reviewers"
+    
+    # PR과 이슈 연동
+    gh pr edit --add-metadata "Closes #$issue_number"
+    
+    echo "Successfully created PR for issue #$issue_number"
+}
+
 # 메인 로직
 case "$1" in
     "list")
@@ -93,8 +190,11 @@ case "$1" in
     "branch")
         create_branch
         ;;
+    "pr")
+        create_pr
+        ;;
     *)
-        echo "Usage: agt {list|branch}"
+        print_help
         exit 1
         ;;
 esac


### PR DESCRIPTION
## 📝 작업

Issue 기반으로 PR을 자동으로 생성해주는 기능을 추가했습니다.
기존의 `agt` 명령어에 `pr` 서브커맨드가 추가되었습니다.
자세한 사용 매뉴얼은 Wiki에 정리했습니다.

## 📒 작업 내용

### 추가된 기능
- `agt pr` 명령어 추가
- 현재 브랜치의 이슈 번호와 타입(FE/BE)을 자동으로 인식
- PR 생성 시 이슈 제목을 PR 제목으로 자동 설정
- CODEOWNERS 파일에서 리뷰어 자동 지정 (본인 제외)
- PR 템플릿에 이슈 번호 자동 삽입
- PR과 이슈 자동 연동 (PR merge 시 이슈 자동 close)

### 동작 예시

```bash
$ git status
On branch feature-fe-#23
Your branch is up to date with 'origin/feature-fe-#23'

$ agt pr
Creating PR with title: [FE] 마이크 버튼 컴포넌트 생성
Base branch: dev-fe
Reviewers: @reviewer1,@reviewer2,@reviewer3
Successfully created PR for issue #23