### PR TITLE
[FE] 게임방 컴포넌트 생성 및 Pagination UI 구현

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -20,7 +20,8 @@
         "react-router-dom": "^6.27.0",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7",
-        "uuid": "^11.0.2"
+        "uuid": "^11.0.2",
+        "zustand": "^5.0.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.13.0",
@@ -6918,6 +6919,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.1.tgz",
+      "integrity": "sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/fe/package.json
+++ b/fe/package.json
@@ -24,7 +24,8 @@
     "react-router-dom": "^6.27.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
-    "uuid": "^11.0.2"
+    "uuid": "^11.0.2",
+    "zustand": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/fe/src/App.css
+++ b/fe/src/App.css
@@ -4,39 +4,3 @@
   padding: 2rem;
   text-align: center;
 }
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
-}

--- a/fe/src/components/ui/badge.tsx
+++ b/fe/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/fe/src/components/ui/card.tsx
+++ b/fe/src/components/ui/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/fe/src/pages/RoomPage/RoomDialog/RoomDialog.tsx
+++ b/fe/src/pages/RoomPage/RoomDialog/RoomDialog.tsx
@@ -9,9 +9,23 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import useRoomStore from '@/store/useRoomStore';
 import { RoomDialogProps } from '@/types/room';
+import { useState } from 'react';
 
 const RoomDialog = ({ open, onOpenChange }: RoomDialogProps) => {
+  const [roomName, setRoomName] = useState('');
+  const [nickname, setNickname] = useState('');
+
+  const addRoom = useRoomStore((state) => state.addRoom);
+
+  const handleSubmit = () => {
+    addRoom(roomName.trim(), nickname.trim());
+    setRoomName('');
+    setNickname('');
+    onOpenChange(false);
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
@@ -28,6 +42,10 @@ const RoomDialog = ({ open, onOpenChange }: RoomDialogProps) => {
             </Label>
             <Input
               id="roomName"
+              value={roomName}
+              onChange={(e) => {
+                setRoomName(e.target.value);
+              }}
               placeholder="방 제목을 입력하세요"
               className="col-span-3"
             />
@@ -38,6 +56,10 @@ const RoomDialog = ({ open, onOpenChange }: RoomDialogProps) => {
             </Label>
             <Input
               id="nickname"
+              value={nickname}
+              onChange={(e) => {
+                setNickname(e.target.value);
+              }}
               placeholder="닉네임을 입력하세요"
               className="col-span-3"
             />
@@ -47,11 +69,17 @@ const RoomDialog = ({ open, onOpenChange }: RoomDialogProps) => {
           <Button
             type="button"
             variant="outline"
-            onClick={() => onOpenChange(false)}
+            onClick={() => {
+              setRoomName('');
+              setNickname('');
+              onOpenChange(false);
+            }}
           >
             취소
           </Button>
-          <Button type="button">확인</Button>
+          <Button type="button" onClick={handleSubmit}>
+            확인
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/fe/src/pages/RoomPage/RoomList/GameRoom.tsx
+++ b/fe/src/pages/RoomPage/RoomList/GameRoom.tsx
@@ -1,0 +1,42 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { GameRoomProps } from '@/types/room';
+import { FaCircle, FaCrown, FaUsers } from 'react-icons/fa6';
+
+const GameRoom = ({ room }: GameRoomProps) => {
+  return (
+    <Card className="flex w-full mt-2">
+      <CardHeader className="space-y-1">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-xl">{room.name}</CardTitle>
+        </div>
+        <div className="space-y-2 text-md text-muted-foreground px-1">
+          <div className="flex items-center gap-2">
+            <FaCrown className="text-yellow-500" />
+            <span>방장: {room.creator}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <FaCircle
+              className={`text-sm ${room.isGameStarted ? 'text-red-500' : 'text-green-500'}`}
+            />
+            <span>
+              상태:{' '}
+              <span
+                className={
+                  room.isGameStarted ? 'text-red-500' : 'text-green-500'
+                }
+              >
+                {room.isGameStarted ? '게임 중' : '대기 중'}
+              </span>
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <FaUsers className="text-gray-500" />
+            <span>인원 수: {room.players.length} / 4</span>
+          </div>
+        </div>
+      </CardHeader>
+    </Card>
+  );
+};
+
+export default GameRoom;

--- a/fe/src/pages/RoomPage/RoomList/Pagination.tsx
+++ b/fe/src/pages/RoomPage/RoomList/Pagination.tsx
@@ -1,0 +1,45 @@
+import { Button } from '@/components/ui/button';
+import { PaginationProps } from '@/types/room';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa6';
+
+const Pagination = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: PaginationProps) => {
+  return (
+    <div className="flex items-center justify-center gap-4 mt-6">
+      <Button
+        variant="outline"
+        size="icon"
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 0}
+      >
+        <FaChevronLeft className="w-4 h-4" />
+      </Button>
+      <div className="flex items-center gap-2">
+        {Array.from({ length: totalPages }, (_, i) => (
+          <Button
+            key={i}
+            variant={currentPage === i ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => onPageChange(i)}
+            className="w-8 h-8"
+          >
+            {i + 1}
+          </Button>
+        ))}
+      </div>
+      <Button
+        variant="outline"
+        size="icon"
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages - 1}
+      >
+        <FaChevronRight className="w-4 h-4" />
+      </Button>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/fe/src/pages/RoomPage/RoomList/RoomList.tsx
+++ b/fe/src/pages/RoomPage/RoomList/RoomList.tsx
@@ -1,0 +1,54 @@
+import { Room } from '@/types/room';
+import { useEffect, useState } from 'react';
+import GameRoom from './GameRoom';
+import Pagination from './Pagination';
+import useRoomStore from '@/store/useRoomStore';
+
+const RoomList = () => {
+  const rooms = useRoomStore((state) => state.rooms);
+  const [currentPage, setCurrentPage] = useState(0);
+
+  const ROOMS_PER_PAGE = 9;
+  const totalPages = Math.ceil(rooms.length / ROOMS_PER_PAGE);
+
+  const currentRooms = rooms.slice(
+    currentPage * ROOMS_PER_PAGE,
+    (currentPage + 1) * ROOMS_PER_PAGE
+  );
+
+  useEffect(() => {
+    if (rooms.length > ROOMS_PER_PAGE * (currentPage + 1)) {
+      setCurrentPage(currentPage + 1);
+    }
+  }, [rooms.length, totalPages]);
+
+  return (
+    <div className="space-y-6 max-h-screen mt-2">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {currentRooms.map((room) => (
+          <GameRoom key={room.id} room={room} />
+        ))}
+        {currentRooms.length > 0 &&
+          currentRooms.length < ROOMS_PER_PAGE &&
+          Array.from({ length: ROOMS_PER_PAGE - currentRooms.length }).map(
+            (_, i) => <div key={`empty-${i}`} className="w-full h-0"></div>
+          )}
+      </div>
+
+      {rooms.length > ROOMS_PER_PAGE && (
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+        />
+      )}
+      {rooms.length === 0 && (
+        <div className="text-center py-8 text-muted-foreground">
+          생성된 방이 없습니다.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RoomList;

--- a/fe/src/pages/RoomPage/index.tsx
+++ b/fe/src/pages/RoomPage/index.tsx
@@ -1,11 +1,13 @@
 import SearchBar from '@/components/common/SearchBar';
 import RoomHeader from './RoomHeader/RoomHeader';
+import RoomList from './RoomList/RoomList';
 
 const RoomPage = () => {
   return (
     <div>
       <RoomHeader />
       <SearchBar />
+      <RoomList />
     </div>
   );
 };

--- a/fe/src/store/useRoomStore.ts
+++ b/fe/src/store/useRoomStore.ts
@@ -1,0 +1,21 @@
+import { Room, RoomStore } from '@/types/room';
+import { create } from 'zustand';
+
+const useRoomStore = create<RoomStore>((set) => ({
+  rooms: [],
+  addRoom: (roomName: string, nickname: string) => {
+    const newRoom: Room = {
+      id: Math.random().toString(36).substr(2, 9),
+      name: roomName,
+      creator: nickname,
+      players: [nickname],
+      isGameStarted: false,
+    };
+
+    set((state) => ({
+      rooms: [...state.rooms, newRoom],
+    }));
+  },
+}));
+
+export default useRoomStore;

--- a/fe/src/types/room.ts
+++ b/fe/src/types/room.ts
@@ -2,3 +2,26 @@ export interface RoomDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
+
+export interface Room {
+  id: string;
+  name: string;
+  creator: string;
+  players: string[];
+  isGameStarted: boolean;
+}
+
+export interface GameRoomProps {
+  room: Room;
+}
+
+export interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+export interface RoomStore {
+  rooms: Room[];
+  addRoom: (roomName: string, nickname: string) => void;
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호
#8 

<br>

## 📝 작업
- RoomList, GameRoom, Pagination 컴포넌트 UI 및 기능 구현
- 전역 상태 관리 Zustand 사용

<br>

## 📒 작업 내용
- 방 만들기 버튼을 누르고 방 제목과 닉네임을 설정한 후 확인 버튼을 클릭하면 GameRoom 컴포넌트를 RoomList에 추가
- GameRoom 컴포넌트는 방 제목, 방장, 상태, 인원 수 표시
- GameRoom은 한 페이지에 3 * 3, 총 9개까지 추가할 수 있고, 9개를 넘어가면 다음 페이지로 추가되면서 페이지 이동
- 수정해야 할 부분: 스크롤 바가 생성되지 않도록(GameRoom height 고정?), Pagination 버튼 하단에 위치 고정할지 고민

## 📺 동작 화면
![game-room-pagination](https://github.com/user-attachments/assets/a6c196f9-e73e-41f7-8fea-067f27cd5d49)