### PR TITLE
[BE] 개설된 게임방의 목록을 가져온다.

### DIFF
--- a/be/gameserver/src/main.ts
+++ b/be/gameserver/src/main.ts
@@ -5,6 +5,8 @@ import { ConfigService } from '@nestjs/config';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.setGlobalPrefix('api');
   const configService = app.get(ConfigService);
 
   const config = new DocumentBuilder()

--- a/be/gameserver/src/modules/rooms/dto/room-data.dto.ts
+++ b/be/gameserver/src/modules/rooms/dto/room-data.dto.ts
@@ -1,27 +1,33 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class RoomDataDto {
-  @ApiProperty({ example: '123124', description: 'Room Id' })
+  @ApiProperty({
+    example: '6f42377f-42ea-42cc-ac1a-b5d2b99d4ced',
+    description: '게임 방 ID',
+  })
   roomId: string;
 
-  @ApiProperty({ example: '게임방123', description: 'Room name' })
+  @ApiProperty({
+    example: '게임방123',
+    description: '게임 방 이름',
+  })
   roomName: string;
 
   @ApiProperty({
     example: 'creatorNickname123',
-    description: 'creatorNickname',
+    description: '방을 생성한 사용자의 닉네임',
   })
   creatorNickname: string;
 
   @ApiProperty({
     example: ['creatorNickname123'],
-    description: 'List of players currently in the room',
+    description: '현재 방에 참여한 플레이어 목록',
   })
   players: string[];
 
   @ApiProperty({
     example: 'waiting',
-    description: 'Current status of the room (e.g., waiting, in-game',
+    description: '현재 방의 상태 (예: 대기 중, 게임 중)',
   })
   status: string;
 }

--- a/be/gameserver/src/modules/rooms/rooms.controller.ts
+++ b/be/gameserver/src/modules/rooms/rooms.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get } from '@nestjs/common';
+import { RedisService } from '../../redis/redis.service';
+import { RoomDataDto } from './dto/room-data.dto';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+@ApiTags('Rooms (REST)')
+@Controller('rooms')
+export class RoomController {
+  constructor(private readonly redisService: RedisService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: '게임 방 목록 조회',
+    description: 'Redis에서 저장된 모든 게임 방 목록을 조회합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '게임 방 목록이 성공적으로 반환됩니다.',
+    type: [RoomDataDto],
+  })
+  async getRooms(): Promise<RoomDataDto[]> {
+    const roomKeys = await this.redisService.keys('room:*');
+
+    const rooms = await Promise.all(
+      roomKeys.map(async (key) => {
+        const roomData = await this.redisService.get<string>(key);
+        return JSON.parse(roomData) as RoomDataDto;
+      }),
+    );
+
+    return rooms;
+  }
+}

--- a/be/gameserver/src/modules/rooms/rooms.controller.ts
+++ b/be/gameserver/src/modules/rooms/rooms.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Logger } from '@nestjs/common';
 import { RedisService } from '../../redis/redis.service';
 import { RoomDataDto } from './dto/room-data.dto';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
@@ -6,6 +6,8 @@ import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 @ApiTags('Rooms (REST)')
 @Controller('rooms')
 export class RoomController {
+  private readonly logger = new Logger(RoomController.name);
+
   constructor(private readonly redisService: RedisService) {}
 
   @Get()
@@ -20,6 +22,7 @@ export class RoomController {
   })
   async getRooms(): Promise<RoomDataDto[]> {
     const roomKeys = await this.redisService.keys('room:*');
+    this.logger.log('게임 방 목록 조회 시작');
 
     const rooms = await Promise.all(
       roomKeys.map(async (key) => {
@@ -27,7 +30,7 @@ export class RoomController {
         return JSON.parse(roomData) as RoomDataDto;
       }),
     );
-
+    this.logger.log(`게임 방 목록 조회 완료, ${rooms.length}개 방 반환`);
     return rooms;
   }
 }

--- a/be/gameserver/src/modules/rooms/rooms.gateway.ts
+++ b/be/gameserver/src/modules/rooms/rooms.gateway.ts
@@ -6,6 +6,7 @@ import {
   ConnectedSocket,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
+import { Logger } from '@nestjs/common';
 import { CreateRoomDto } from './dto/create-room.dto';
 import { RedisService } from '../../redis/redis.service';
 import { RoomDataDto } from './dto/room-data.dto';
@@ -13,6 +14,8 @@ import { v4 as uuidv4 } from 'uuid';
 
 @WebSocketGateway({ namespace: '/rooms' })
 export class RoomsGateway {
+  private readonly logger = new Logger(RoomsGateway.name);
+
   @WebSocketServer()
   server: Server;
 
@@ -24,6 +27,10 @@ export class RoomsGateway {
     @ConnectedSocket() client: Socket,
   ) {
     const { roomName, creatorNickname } = createRoomDto;
+    this.logger.log(
+      `Room creation requested: ${roomName} by ${creatorNickname}`,
+    );
+
     const roomId = uuidv4();
     const roomData: RoomDataDto = {
       roomId,
@@ -33,9 +40,15 @@ export class RoomsGateway {
       status: 'waiting',
     };
 
-    await this.redisService.set(`room:${roomId}`, JSON.stringify(roomData));
+    try {
+      await this.redisService.set(`room:${roomId}`, JSON.stringify(roomData));
+      this.logger.log(`Room created successfully: ${roomId}`);
 
-    client.join(roomId);
-    client.emit('roomCreated', roomData);
+      client.join(roomId);
+      client.emit('roomCreated', roomData);
+    } catch (error) {
+      this.logger.error(`Error creating room: ${error.message}`, error.stack);
+      throw error;
+    }
   }
 }

--- a/be/gameserver/src/modules/rooms/rooms.module.ts
+++ b/be/gameserver/src/modules/rooms/rooms.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { RedisModule } from 'src/redis/redis.module';
 import { RoomsGateway } from './rooms.gateway';
 import { RoomsWebSocketController } from './rooms.websocket.controller';
+import { RoomController } from './rooms.controller';
 
 @Module({
   imports: [RedisModule],
   providers: [RoomsGateway],
-  controllers: [RoomsWebSocketController],
+  controllers: [RoomsWebSocketController, RoomController],
 })
 export class RoomsModule {}

--- a/be/gameserver/src/modules/rooms/rooms.websocket.controller.ts
+++ b/be/gameserver/src/modules/rooms/rooms.websocket.controller.ts
@@ -10,7 +10,7 @@ export class RoomsWebSocketController {
   @ApiOperation({
     summary: 'Create Room (WebSocket Event)',
     description:
-      'ws/clovapatra.com/rooms 에서 "createRoom" 이벤트를 emit해 사용합니다. 성공적으로 게임방이 생성되면 "roomCreated" 이벤트를 수신해 RoomData를 받을 수 있습니다.',
+      'ws://clovapatra.com/rooms 에서 "createRoom" 이벤트를 emit해 사용합니다. 성공적으로 게임방이 생성되면 "roomCreated" 이벤트를 수신해 RoomData를 받을 수 있습니다.',
   })
   @ApiBody({ type: CreateRoomDto })
   @ApiResponse({

--- a/be/gameserver/src/redis/redis.service.ts
+++ b/be/gameserver/src/redis/redis.service.ts
@@ -17,4 +17,8 @@ export class RedisService {
   async delete(key: string): Promise<void> {
     await this.redisClient.del(key);
   }
+
+  async keys(pattern: string): Promise<string[]> {
+    return this.redisClient.keys(pattern);
+  }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

#4 

## 📝 작업

* api prefix 적용
* 게임방 목록 조회 기능 추가
* logger 적용


<br>

## 📒 작업 내용

### api prefix 적용
모든 API에 `api/` prefix를 적용했습니다.
**웹소켓 이벤트는 적용되지 않습니다**
사용예시 : `api/rooms`

### 게임방 목록 조회 기능 추가
현재 만들어진 게임방 목록을 조회할 수 있는 API 엔드포인트를 추가했습니다. GET: api/rooms

### logger 적용
프로그램 흐름을 간단하게 알 수 있도록 기본 logger를 controller, websocketGateway에 추가했습니다.
따로 파일에 저장하지는 않았고, **일단 console에만 출력할 수 있도록 했습니다.**
