### PR TITLE
[BE] 시그널링 서버 로직 개선

### DIFF
--- a/be/signalingServer/src/services/room.service.js
+++ b/be/signalingServer/src/services/room.service.js
@@ -1,0 +1,162 @@
+class RoomService {
+  constructor() {
+    // 방 정보를 저장하는 Map
+    // Map<roomId, RoomInfo>
+    this.rooms = new Map();
+  }
+
+  /**
+   * 방 정보 구조
+   * {
+   *   users: Map<socketId, UserInfo>
+   *   // 모든 사용자가 방 정보를 받았는지 확인하는 카운터
+   *   receivedInfoCount: number,
+   * }
+   *
+   * UserInfo 구조
+   * {
+   *   socketId: string,
+   *   sdp: RTCSessionDescription,
+   *   candidates: RTCIceCandidate[],
+   *   deviceId: string, // 오디오 장치 ID
+   *   timestamp: number // 마지막 업데이트 시간
+   * }
+   */
+
+  /**
+   * 방에 사용자 추가
+   * @param {string} roomId - 방 ID
+   * @param {string} socketId - 소켓 ID
+   * @param {Object} userInfo - 사용자 정보 (SDP, ICE candidates 등)
+   */
+  addUser(roomId, socketId, userInfo) {
+    console.log(`[RoomService] 사용자 ${socketId}가 방 ${roomId}에 참가 시도`);
+
+    if (!this.rooms.has(roomId)) {
+      console.log(`[RoomService] 새로운 방 ${roomId} 생성`);
+      this.rooms.set(roomId, {
+        users: new Map(),
+        receivedInfoCount: 0,
+      });
+    }
+
+    const room = this.rooms.get(roomId);
+    room.users.set(socketId, {
+      ...userInfo,
+      timestamp: Date.now(),
+    });
+
+    console.log(`[RoomService] 방 ${roomId}의 현재 사용자 수: ${room.users.size}`);
+    return Array.from(room.users.values());
+  }
+
+  /**
+   * 방에서 사용자 제거
+   * @param {string} socketId - 소켓 ID
+   */
+  removeUser(socketId) {
+    console.log(`[RoomService] 사용자 ${socketId} 제거 시도`);
+
+    for (const [roomId, room] of this.rooms) {
+      if (room.users.has(socketId)) {
+        room.users.delete(socketId);
+        console.log(`[RoomService] 사용자 ${socketId}가 방 ${roomId}에서 제거됨`);
+
+        if (room.users.size === 0) {
+          this.rooms.delete(roomId);
+          console.log(`[RoomService] 빈 방 ${roomId} 삭제`);
+        }
+        return roomId;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * 사용자 정보 업데이트 (SDP, ICE candidate 등)
+   * @param {string} roomId - 방 ID
+   * @param {string} socketId - 소켓 ID
+   * @param {Object} updates - 업데이트할 정보
+   */
+  updateUser(roomId, socketId, updates) {
+    console.log(`[RoomService] 사용자 ${socketId} 정보 업데이트`);
+
+    const room = this.rooms.get(roomId);
+    if (!room) return false;
+
+    const userInfo = room.users.get(socketId);
+    if (!userInfo) return false;
+
+    room.users.set(socketId, {
+      ...userInfo,
+      ...updates,
+      timestamp: Date.now(),
+    });
+
+    console.log(`[RoomService] 사용자 ${socketId} 정보 업데이트 완료`);
+    return true;
+  }
+
+  /**
+   * 방 정보 수신 확인
+   * @param {string} roomId - 방 ID
+   * @returns {boolean} - 모든 사용자가 정보를 받았는지 여부
+   */
+  confirmReceived(roomId) {
+    const room = this.rooms.get(roomId);
+    if (!room) return false;
+
+    room.receivedInfoCount++;
+    console.log(`[RoomService] 방 ${roomId}의 정보 수신 확인: ${room.receivedInfoCount}/${room.users.size}`);
+
+    if (room.receivedInfoCount >= room.users.size) {
+      room.receivedInfoCount = 0;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * P2P 연결 계획 생성
+   * @param {string} roomId - 방 ID
+   * @returns {Array<{from: string, to: string}>} - 연결 계획
+   */
+  createConnectionPlan(roomId) {
+    const room = this.rooms.get(roomId);
+    if (!room) return [];
+
+    const users = Array.from(room.users.keys());
+    const connections = [];
+
+    // 모든 사용자를 서로 연결
+    for (let i = 0; i < users.length; i++) {
+      for (let j = i + 1; j < users.length; j++) {
+        connections.push({
+          from: users[i],
+          to: users[j],
+        });
+      }
+    }
+
+    console.log(`[RoomService] 방 ${roomId}의 연결 계획 생성:`, connections);
+    return connections;
+  }
+
+  /**
+   * 방의 모든 사용자 정보 반환
+   * @param {string} roomId - 방 ID
+   */
+  getRoomInfo(roomId) {
+    const room = this.rooms.get(roomId);
+    if (!room) return null;
+
+    return {
+      users: Array.from(room.users.entries()).map(([socketId, info]) => ({
+        socketId,
+        ...info,
+      })),
+    };
+  }
+}
+
+module.exports = RoomService;

--- a/be/signalingServer/src/services/socket.service.js
+++ b/be/signalingServer/src/services/socket.service.js
@@ -1,75 +1,93 @@
+const RoomService = require("./room.service");
+
 class SocketService {
   constructor(io) {
     this.io = io;
+    this.roomService = new RoomService();
   }
 
-  async handleConnection(socket) {
-    console.log(`New user connected: ${socket.id}`);
+  /**
+   * 새로운 소켓 연결 처리
+   * @param {Socket} socket - Socket.io 소켓 객체
+   */
+  handleConnection(socket) {
+    console.log(`[SocketService] 새로운 사용자 연결: ${socket.id}`);
 
-    // Handle room joining requests
-    socket.on("join", (roomId) => {
-      // Get current number of clients in the room
-      const numberOfClients = this.io.sockets.adapter.rooms.get(roomId)?.size || 0;
+    // 방 참가 요청 처리
+    socket.on("join_room", (data) => {
+      const { roomId, sdp, candidates, deviceId } = data;
+      console.log(`[SocketService] 사용자 ${socket.id}가 방 ${roomId} 참가 요청`);
 
-      if (numberOfClients === 0) {
-        // If room is empty, create new room
-        socket.join(roomId);
-        socket.emit("room_created", roomId);
-        console.log(`Room ${roomId} created by ${socket.id}`);
-      } else if (numberOfClients >= 1) {
-        // If room exists, join the room
-        socket.join(roomId);
+      // 방에 사용자 추가
+      socket.join(roomId);
+      this.roomService.addUser(roomId, socket.id, {
+        sdp,
+        candidates,
+        deviceId,
+      });
 
-        // Get list of all clients in the room
-        const clients = Array.from(this.io.sockets.adapter.rooms.get(roomId));
-        socket.emit("room_joined", {
-          socketId: socket.id,
-          numberOfClients,
-          clientList: clients,
-          roomId,
-        });
-        console.log(`User ${socket.id} joined room ${roomId}`);
+      // 방의 모든 사용자에게 업데이트된 정보 전송
+      this.broadcastRoomUpdate(roomId);
+    });
+
+    // 방 정보 수신 확인
+    socket.on("room_info_received", (roomId) => {
+      console.log(`[SocketService] 사용자 ${socket.id}가 방 ${roomId} 정보 수신 확인`);
+
+      if (this.roomService.confirmReceived(roomId)) {
+        // 모든 사용자가 정보를 받았으면 연결 계획 전송
+        const plan = this.roomService.createConnectionPlan(roomId);
+        this.io.to(roomId).emit("start_connections", plan);
       }
     });
 
-    // Handle call initiation
-    socket.on("start_call", (roomId) => {
-      const clients = Array.from(this.io.sockets.adapter.rooms.get(roomId));
-      socket.to(roomId).emit("start_call", {
-        fromId: socket.id,
-        clientCount: clients.length,
-        clientList: clients,
-        roomId,
-      });
-    });
-
-    // Handle WebRTC signaling
-    socket.on("webrtc_offer", (event) => {
-      this.io.to(event.toId).emit("webrtc_offer", {
-        sdp: event.sdp,
+    // WebRTC 시그널링 처리
+    socket.on("webrtc_offer", (data) => {
+      console.log(`[SocketService] WebRTC Offer: ${socket.id} -> ${data.toId}`);
+      this.io.to(data.toId).emit("webrtc_offer", {
+        sdp: data.sdp,
         fromId: socket.id,
       });
     });
 
-    socket.on("webrtc_answer", (event) => {
-      this.io.to(event.toId).emit("webrtc_answer", {
-        sdp: event.sdp,
+    socket.on("webrtc_answer", (data) => {
+      console.log(`[SocketService] WebRTC Answer: ${socket.id} -> ${data.toId}`);
+      this.io.to(data.toId).emit("webrtc_answer", {
+        sdp: data.sdp,
         fromId: socket.id,
       });
     });
 
-    socket.on("webrtc_ice_candidate", (event) => {
-      this.io.to(event.toId).emit("webrtc_ice_candidate", {
-        candidate: event.candidate,
+    socket.on("webrtc_ice_candidate", (data) => {
+      console.log(`[SocketService] ICE Candidate: ${socket.id} -> ${data.toId}`);
+      this.io.to(data.toId).emit("webrtc_ice_candidate", {
+        candidate: data.candidate,
         fromId: socket.id,
       });
     });
 
-    // Handle disconnection
+    // 연결 해제 처리
     socket.on("disconnect", () => {
-      this.io.sockets.emit("user_disconnected", socket.id);
-      console.log(`User disconnected: ${socket.id}`);
+      console.log(`[SocketService] 사용자 연결 해제: ${socket.id}`);
+      const roomId = this.roomService.removeUser(socket.id);
+
+      if (roomId) {
+        this.io.to(roomId).emit("user_disconnected", socket.id);
+        this.broadcastRoomUpdate(roomId);
+      }
     });
+  }
+
+  /**
+   * 방의 모든 사용자에게 업데이트된 정보 전송
+   * @param {string} roomId - 방 ID
+   */
+  broadcastRoomUpdate(roomId) {
+    const roomInfo = this.roomService.getRoomInfo(roomId);
+    if (roomInfo) {
+      console.log(`[SocketService] 방 ${roomId} 정보 브로드캐스트`);
+      this.io.to(roomId).emit("room_info", roomInfo);
+    }
   }
 }
 


### PR DESCRIPTION
## #️⃣ 이슈 번호
#86

<br>

## 📝 작업

* 시그널링 로직을 개선하고 버그를 수정했습니다.

<br>

## 📒 작업 내용

* Client-Side에서 방장의 개념을 삭제하고 방장의 역할을 서버에서 처리하도록 했습니다.
* 서버에서 ConnectionPlan을 생성하도록 했습니다.
  * 누가 누구에게 Offer를 보내야 할 지 서버가 정해서 BroadCast 합니다.
  * 예를 들어, 사용자 A, B, C, D가 있을 때, A가 B, C, D에게 Offer를 보내고, B는 C, D에게, C는 D에게 Offer를 보내게 되면 모든 사용자가 P2P Mesh로 연결되게 됩니다.