### PR TITLE
[FE] 게임 시작, 준비, 강퇴 버튼 컴포넌트 생성

### DIFF
--- a/fe/src/pages/GamePage/GameScreen/GameScreen.tsx
+++ b/fe/src/pages/GamePage/GameScreen/GameScreen.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Gamepad2, CheckCircle2 } from 'lucide-react';
+import useRoomStore from '@/stores/zustand/useRoomStore';
+
+const GameScreen = () => {
+  const [isReady, setIsReady] = useState(false);
+  const { currentRoom, currentPlayer, setCurrentPlayer } = useRoomStore();
+
+  useEffect(() => {
+    if (!currentPlayer) {
+      const nickname = sessionStorage.getItem('user_nickname');
+      if (nickname) {
+        setCurrentPlayer(nickname);
+      }
+    }
+  }, [currentPlayer, setCurrentPlayer]);
+
+  if (!currentRoom) return null;
+
+  const isHost = currentPlayer === currentRoom.hostNickname;
+
+  // 방장을 제외한 나머지 플레이어들의 준비 상태 체크
+  const allPlayersReady = currentRoom.players
+    .slice(1) // 첫 번째 플레이어(방장)를 제외
+    .every((player) => player.isReady);
+
+  const handleReady = () => {
+    setIsReady(true);
+    // TODO: 서버에 준비 상태 전송 로직 추가 필요
+  };
+
+  const handleGameStart = () => {
+    // TODO: 게임 시작 로직 추가 필요
+  };
+
+  // 방장인지 아닌지로 버튼 분기
+  return (
+    <div className="h-[27rem] bg-muted rounded-lg flex flex-col items-center justify-center space-y-4">
+      {isHost ? (
+        <Button
+          size="lg"
+          disabled={!allPlayersReady}
+          onClick={handleGameStart}
+          className="font-galmuri px-8 py-6 text-lg"
+        >
+          <Gamepad2 className="mr-2" />
+          게임 시작
+        </Button>
+      ) : (
+        <Button
+          size="lg"
+          disabled={isReady}
+          onClick={handleReady}
+          className={`font-galmuri px-8 py-6 text-lg ${isReady ? 'bg-green-500 hover:bg-green-500' : ''}`}
+        >
+          <CheckCircle2 className="mr-2 h-5 w-5" />
+          {isReady ? '준비 완료' : '게임 준비'}
+        </Button>
+      )}
+
+      {isHost && !allPlayersReady && (
+        <p className="font-galmuri text-sm text-muted-foreground mt-2">
+          모든 플레이어가 준비를 완료해야 게임을 시작할 수 있습니다.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default GameScreen;

--- a/fe/src/pages/GamePage/PlayerList/Player.tsx
+++ b/fe/src/pages/GamePage/PlayerList/Player.tsx
@@ -1,23 +1,18 @@
 import { Card, CardContent } from '@/components/ui/card';
-import { PlayerProps } from '@/types/playerTypes';
 import { FaCrown } from 'react-icons/fa6';
 import VolumeBar from './VolumeBar';
+import { PlayerProps } from '@/types/roomTypes';
 
-const Player = ({
-  playerNickname,
-  isHost = false,
-  isAudioOn,
-  isReady = false,
-}: PlayerProps) => {
+const Player = ({ playerNickname, isReady }: PlayerProps) => {
   return (
     <Card className="h-full">
       <CardContent className="flex h-[4.7rem] items-center justify-between p-4">
         <div className="flex items-center gap-2">
-          {isHost && <FaCrown className="text-yellow-500" />}
+          <FaCrown className="text-yellow-500" />
           <span className="font-galmuri">{playerNickname}</span>
           {isReady && <span className="text-sm text-green-500">준비 완료</span>}
         </div>
-        <VolumeBar isOn={isAudioOn} />
+        <VolumeBar />
       </CardContent>
     </Card>
   );

--- a/fe/src/pages/GamePage/PlayerList/Player.tsx
+++ b/fe/src/pages/GamePage/PlayerList/Player.tsx
@@ -3,21 +3,40 @@ import { FaCrown } from 'react-icons/fa6';
 import VolumeBar from './VolumeBar';
 import { PlayerProps } from '@/types/roomTypes';
 import { isHost } from '@/utils/playerUtils';
+import useRoomStore from '@/stores/zustand/useRoomStore';
+import { Button } from '@/components/ui/button';
 
 const Player = ({ playerNickname, isReady }: PlayerProps) => {
+  const { currentRoom, currentPlayer } = useRoomStore();
+  const isCurrentPlayerHost = currentPlayer === currentRoom?.hostNickname;
+  const isPlayerHost = isHost(playerNickname);
+
+  const handleKick = () => {
+    // TODO: 강퇴 로직 구현
+    console.log(`강퇴: ${playerNickname}`);
+  };
+
   return (
     <Card className="h-full">
       <CardContent className="flex h-[4.7rem] items-center justify-between p-4">
         <div className="flex items-center gap-2">
-          {isHost(playerNickname) ? (
-            <FaCrown className="text-yellow-500" />
-          ) : (
-            ''
-          )}
+          {isPlayerHost ? <FaCrown className="text-yellow-500" /> : ''}
           <span className="font-galmuri">{playerNickname}</span>
           {isReady && <span className="text-sm text-green-500">준비 완료</span>}
         </div>
-        <VolumeBar />
+        <div className="flex items-center gap-4">
+          <VolumeBar />
+          {isCurrentPlayerHost && !isPlayerHost && (
+            <Button
+              variant="outline"
+              size="icon"
+              className="font-galmuri text-muted-foreground hover:text-destructive"
+              onClick={handleKick}
+            >
+              강퇴
+            </Button>
+          )}
+        </div>
       </CardContent>
     </Card>
   );

--- a/fe/src/pages/GamePage/PlayerList/Player.tsx
+++ b/fe/src/pages/GamePage/PlayerList/Player.tsx
@@ -2,13 +2,18 @@ import { Card, CardContent } from '@/components/ui/card';
 import { FaCrown } from 'react-icons/fa6';
 import VolumeBar from './VolumeBar';
 import { PlayerProps } from '@/types/roomTypes';
+import { isHost } from '@/utils/playerUtils';
 
 const Player = ({ playerNickname, isReady }: PlayerProps) => {
   return (
     <Card className="h-full">
       <CardContent className="flex h-[4.7rem] items-center justify-between p-4">
         <div className="flex items-center gap-2">
-          <FaCrown className="text-yellow-500" />
+          {isHost(playerNickname) ? (
+            <FaCrown className="text-yellow-500" />
+          ) : (
+            ''
+          )}
           <span className="font-galmuri">{playerNickname}</span>
           {isReady && <span className="text-sm text-green-500">준비 완료</span>}
         </div>

--- a/fe/src/pages/GamePage/PlayerList/PlayerList.tsx
+++ b/fe/src/pages/GamePage/PlayerList/PlayerList.tsx
@@ -1,6 +1,6 @@
 import { RULES } from '@/constants/rules';
-import { PlayerProps } from '@/types/playerTypes';
 import Player from './Player';
+import { PlayerProps } from '@/types/roomTypes';
 
 interface PlayerListProps {
   players: PlayerProps[];

--- a/fe/src/pages/GamePage/PlayerList/VolumeBar.tsx
+++ b/fe/src/pages/GamePage/PlayerList/VolumeBar.tsx
@@ -2,16 +2,12 @@ import { Slider } from '@/components/ui/slider';
 import { HiSpeakerWave, HiSpeakerXMark } from 'react-icons/hi2';
 import { useState } from 'react';
 
-interface AudioControlProps {
-  isOn: boolean;
-}
-
-const VolumeBar = ({ isOn }: AudioControlProps) => {
+const VolumeBar = () => {
   const [volume, setVolume] = useState(50);
 
   return (
     <div className="flex items-center gap-2">
-      {volume > 0 && isOn ? (
+      {volume > 0 ? (
         <HiSpeakerWave className="h-4 w-4" />
       ) : (
         <HiSpeakerXMark className="h-4 w-4 text-muted-foreground" />

--- a/fe/src/pages/GamePage/index.tsx
+++ b/fe/src/pages/GamePage/index.tsx
@@ -6,9 +6,9 @@ import ExitDialog from './GameDialog/ExitDialog';
 import { useReconnect } from '@/hooks/useReconnect';
 import { useBackExit } from '@/hooks/useBackExit';
 import { NotFound } from '@/components/common/NotFound';
+import GameScreen from './GameScreen/GameScreen';
 
 const GamePage = () => {
-  const [isAudioOn, setIsAudioOn] = useState(true);
   const [showExitDialog, setShowExitDialog] = useState(false);
   const { currentRoom } = useRoomStore();
 
@@ -26,9 +26,7 @@ const GamePage = () => {
   return (
     <div className="h-screen relative p-4">
       <div className="space-y-6">
-        <div className="h-[27rem] bg-muted rounded-lg flex items-center justify-center">
-          Game Screen
-        </div>
+        <GameScreen />
         <PlayerList
           players={currentRoom.players.map((player) => ({
             playerNickname: player.playerNickname,

--- a/fe/src/pages/GamePage/index.tsx
+++ b/fe/src/pages/GamePage/index.tsx
@@ -30,10 +30,8 @@ const GamePage = () => {
           Game Screen
         </div>
         <PlayerList
-          players={currentRoom.players.map((playerNickname) => ({
-            playerNickname,
-            isHost: playerNickname === currentRoom.hostNickname,
-            isAudioOn,
+          players={currentRoom.players.map((player) => ({
+            playerNickname: player.playerNickname,
             isReady: false,
           }))}
         />

--- a/fe/src/pages/RoomListPage/RoomDialog/CreateDialog.tsx
+++ b/fe/src/pages/RoomListPage/RoomDialog/CreateDialog.tsx
@@ -22,6 +22,7 @@ const CreateDialog = ({ open, onOpenChange }: RoomDialogProps) => {
   const [hostNickname, setHostNickname] = useState('');
   const navigate = useNavigate();
   const currentRoom = useRoomStore((state) => state.currentRoom);
+  const setCurrentPlayer = useRoomStore((state) => state.setCurrentPlayer);
 
   useEffect(() => {
     if (currentRoom) {
@@ -45,8 +46,8 @@ const CreateDialog = ({ open, onOpenChange }: RoomDialogProps) => {
 
       // 방장 닉네임 저장
       sessionStorage.setItem('user_nickname', hostNickname.trim());
-      // sessionStorage.setItem('room_name', roomName.trim());
-      // sessionStorage.setItem('user_role', 'host');
+
+      setCurrentPlayer(hostNickname.trim());
 
       gameSocket.connect();
       signalingSocket.connect();

--- a/fe/src/pages/RoomListPage/RoomDialog/JoinDialog.tsx
+++ b/fe/src/pages/RoomListPage/RoomDialog/JoinDialog.tsx
@@ -26,6 +26,7 @@ const JoinDialog = ({ open, onOpenChange, roomId }: JoinDialogProps) => {
   const navigate = useNavigate();
   const { rooms, setCurrentRoom } = useRoomStore();
   const currentRoom = rooms.find((room) => room.roomId === roomId);
+  const setCurrentPlayer = useRoomStore((state) => state.setCurrentPlayer);
 
   const resetAndClose = () => {
     setPlayerNickname('');
@@ -43,9 +44,10 @@ const JoinDialog = ({ open, onOpenChange, roomId }: JoinDialogProps) => {
 
       // 참가자 닉네임 저장
       sessionStorage.setItem('user_nickname', playerNickname.trim());
-      // sessionStorage.setItem('user_role', 'player');
 
       setCurrentRoom(currentRoom);
+      setCurrentPlayer(playerNickname.trim());
+
       gameSocket.joinRoom(roomId, playerNickname.trim());
       await signalingSocket.joinRoom(currentRoom);
 

--- a/fe/src/pages/RoomListPage/RoomDialog/JoinDialog.tsx
+++ b/fe/src/pages/RoomListPage/RoomDialog/JoinDialog.tsx
@@ -13,7 +13,7 @@ import { gameSocket } from '@/services/gameSocket';
 import { signalingSocket } from '@/services/signalingSocket';
 import useRoomStore from '@/stores/zustand/useRoomStore';
 import { RoomDialogProps } from '@/types/roomTypes';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 interface JoinDialogProps extends RoomDialogProps {

--- a/fe/src/services/gameSocket.ts
+++ b/fe/src/services/gameSocket.ts
@@ -3,7 +3,7 @@ import {
   ClientToServerEvents,
   ServerToClientEvents,
 } from '@/types/socketTypes';
-import { Room } from '@/types/roomTypes';
+import { PlayerProps, Room } from '@/types/roomTypes';
 import { SocketService } from './SocketService';
 import useRoomStore from '@/stores/zustand/useRoomStore';
 import { ENV } from '@/config/env';
@@ -47,14 +47,16 @@ class GameSocket extends SocketService {
       store.setCurrentRoom(room);
     });
 
-    this.socket.on('updateUsers', (players: string[]) => {
+    this.socket.on('updateUsers', (players: PlayerProps[]) => {
       const { currentRoom, setCurrentRoom } = useRoomStore.getState();
+
+      console.log(players);
 
       if (currentRoom) {
         setCurrentRoom({
           ...currentRoom,
           players,
-          hostNickname: players[0],
+          hostNickname: players[0].playerNickname,
         });
       }
     });

--- a/fe/src/services/gameSocket.ts
+++ b/fe/src/services/gameSocket.ts
@@ -50,8 +50,6 @@ class GameSocket extends SocketService {
     this.socket.on('updateUsers', (players: PlayerProps[]) => {
       const { currentRoom, setCurrentRoom } = useRoomStore.getState();
 
-      console.log(players);
-
       if (currentRoom) {
         setCurrentRoom({
           ...currentRoom,

--- a/fe/src/stores/zustand/useRoomStore.ts
+++ b/fe/src/stores/zustand/useRoomStore.ts
@@ -5,16 +5,19 @@ import { devtools } from 'zustand/middleware';
 interface RoomStore {
   rooms: Room[];
   currentRoom: Room | null;
+  currentPlayer: string | null;
 }
 
 interface RoomActions {
   setRooms: (rooms: Room[]) => void;
   setCurrentRoom: (room: Room) => void;
+  setCurrentPlayer: (nickname: string) => void;
 }
 
 const initialState: RoomStore = {
   rooms: [],
   currentRoom: null,
+  currentPlayer: null,
 };
 
 const useRoomStore = create<RoomStore & RoomActions>()(
@@ -29,6 +32,11 @@ const useRoomStore = create<RoomStore & RoomActions>()(
     setCurrentRoom: (room) =>
       set(() => ({
         currentRoom: room,
+      })),
+
+    setCurrentPlayer: (nickname) =>
+      set(() => ({
+        currentPlayer: nickname,
       })),
   }))
 );

--- a/fe/src/types/playerTypes.ts
+++ b/fe/src/types/playerTypes.ts
@@ -1,6 +1,0 @@
-export interface PlayerProps {
-  playerNickname: string;
-  isHost?: boolean;
-  isAudioOn: boolean;
-  isReady?: boolean;
-}

--- a/fe/src/types/roomTypes.ts
+++ b/fe/src/types/roomTypes.ts
@@ -1,8 +1,13 @@
+export interface PlayerProps {
+  playerNickname: string;
+  isReady: boolean;
+}
+
 export interface Room {
   roomId: string;
   roomName: string;
   hostNickname: string;
-  players: string[];
+  players: PlayerProps[];
   status: 'waiting' | 'playing';
 }
 

--- a/fe/src/utils/playerUtils.ts
+++ b/fe/src/utils/playerUtils.ts
@@ -1,0 +1,7 @@
+import useRoomStore from '@/stores/zustand/useRoomStore';
+
+export const isHost = (playerNickname: string) => {
+  const { currentRoom } = useRoomStore();
+
+  return playerNickname === currentRoom.hostNickname;
+};


### PR DESCRIPTION
## #️⃣ 이슈 번호
#111

<br>

## 📝 작업
- updateUsers로 받아오는 players 데이터 변경으로 타입 및 관련 코드 리팩터링
- 현재 페이지의 player 닉네임(자기자신) 상태 저장
- 게임 시작, 준비 버튼 컴포넌트 생성
- 강퇴 버튼 컴포넌트 생성

<br>

## 📒 작업 내용
- players 닉네임(string) 배열에서 객체 배열로 변경하여 타입 및 관련 코드 변경함
- GameScreen에서 자기자신이 방장이 아닌 걸 알기 위해서 currentPlayer 상태 저장하고, 새로고침 시 sessionStorage에서 가져와서 다시 저장
- 방장은 게임 시작 버튼, 참가자는 게임 준비 버튼이 보이고, 참가자들이 게임 준비 버튼을 누르면 준비 완료 버튼으로 UI 바뀌도록 구현
- 모든 참가자들이 준비 완료가 되면 방장의 게임 시작 버튼이 활성화 (isReady 정보를 서버에서 가져오기로 해서 현재 화면 동작으로 확인 불가)
- 방장에게만 참가자들을 강퇴할 수 있는 강퇴 버튼이 보임

<br>

## 📺 동작 화면
![game-start-ready-button](https://github.com/user-attachments/assets/3d59a378-8769-4889-9f1c-15f10b50fba7)

<br>

## 💣 문제
- 게임방 생성해서 방장이 입장했을 때 게임 시작 버튼이 비활성 상태이도록 바꿔야 함
- 게임 준비 <-> 준비 완료 토글 되도록 해야 함