### PR TITLE
[BE] 시그널링 서버에서 사용자의 닉네임을 리턴한다.(2)

### DIFF
--- a/be/signalingServer/src/services/room.service.js
+++ b/be/signalingServer/src/services/room.service.js
@@ -156,6 +156,10 @@ class RoomService {
         socketId,
         ...info,
       })),
+      userMappings: Array.from(room.users.entries()).reduce((mappings, [socketId, info]) => {
+        mappings[info.playerNickname] = socketId;
+        return mappings;
+      }, {}),
     };
   }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호
#123

<br>

## 📝 작업

* 닉네임과 소켓 매핑 정보 누락 수정

<br>

## 📒 작업 내용

* 닉네임과 소켓 매핑 정보 누락 수정