### PR TITLE
[FE] 방장은 다른 참가자를 강제퇴장 시킬 수 있다.

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "^18.3.1",
         "react-icons": "^5.3.0",
         "react-router-dom": "^6.27.0",
+        "react-toastify": "^10.0.6",
         "socket.io-client": "^4.8.1",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7",
@@ -1377,6 +1378,39 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.2.tgz",
+      "integrity": "sha512-Z6pqSzmAP/bFJoqMAston4eSNa+ud44NSZTiZUmUen+IOZ5nBY8kzuU5WDBVyFXPtcW6yUalOHsxM/BP6Sv8ww==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-collection": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-presence": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
@@ -1466,6 +1500,28 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.0.tgz",
+      "integrity": "sha512-N8MDZqtgCgG5S3aV60INAB475osJousYpZ4cTJ2cFbMpdHS5Y6loLTH8LPtkj2QN0x93J30HT/M3qJXM0+lyeQ==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -5715,6 +5771,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.6.tgz",
+      "integrity": "sha512-yYjp+omCDf9lhZcrZHKbSq7YMuK0zcYkDFTzfRFgTXkTFHZ1ToxwAonzA4JI5CxA91JpjFLmwEsZEgfYfOqI1A==",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {

--- a/fe/package.json
+++ b/fe/package.json
@@ -27,6 +27,7 @@
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",
     "react-router-dom": "^6.27.0",
+    "react-toastify": "^10.0.6",
     "socket.io-client": "^4.8.1",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",

--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -3,6 +3,8 @@ import './App.css';
 import GamePage from './pages/GamePage';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import RoomListPage from './pages/RoomListPage';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 const queryClient = new QueryClient();
 
@@ -16,6 +18,7 @@ function App() {
             <Route path="/game/:roomId" element={<GamePage />} />
           </Routes>
         </BrowserRouter>
+        <ToastContainer />
       </div>
     </QueryClientProvider>
   );

--- a/fe/src/hooks/useAudioManager.ts
+++ b/fe/src/hooks/useAudioManager.ts
@@ -2,7 +2,6 @@ import { useCallback } from 'react';
 
 export const useAudioManager = () => {
   const setAudioStream = useCallback((peerId: string, stream: MediaStream) => {
-    console.log('setAudioStream 호출됨:', peerId);
     const existingAudio = document.getElementById(
       `audio-${peerId}`
     ) as HTMLAudioElement;
@@ -18,22 +17,15 @@ export const useAudioManager = () => {
     audioElement.volume = 0.5; // 초기 볼륨
 
     document.body.appendChild(audioElement);
-    console.log('오디오 엘리먼트 생성됨:', {
-      peerId,
-      volume: audioElement.volume,
-    });
   }, []);
 
   const setVolume = useCallback((peerId: string, volume: number) => {
-    console.log('1. setVolume 호출됨:', { peerId, volume });
     const audioElement = document.getElementById(
       `audio-${peerId}`
     ) as HTMLAudioElement;
 
     if (audioElement) {
-      console.log('3. 볼륨 변경 전:', audioElement.volume);
       audioElement.volume = volume;
-      console.log('4. 볼륨 변경 후:', audioElement.volume);
     } else {
       console.log('audioElement를 찾을 수 없음:', peerId);
     }

--- a/fe/src/pages/GamePage/GameDialog/KickDialog.tsx
+++ b/fe/src/pages/GamePage/GameDialog/KickDialog.tsx
@@ -1,0 +1,53 @@
+// pages/GamePage/PlayerList/KickDialog.tsx
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { RoomDialogProps } from '@/types/roomTypes';
+import { gameSocket } from '@/services/gameSocket';
+import { cn } from '@/lib/utils';
+
+interface KickDialogProps extends RoomDialogProps {
+  playerNickname: string;
+}
+
+const KickDialog = ({
+  open,
+  onOpenChange,
+  playerNickname,
+}: KickDialogProps) => {
+  const handleKick = () => {
+    gameSocket.kickPlayer(playerNickname);
+    onOpenChange(false);
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="font-galmuri sm:max-w-[22rem]">
+        <AlertDialogHeader>
+          <AlertDialogTitle>강제 퇴장 확인</AlertDialogTitle>
+          <AlertDialogDescription>
+            {playerNickname}님을 정말로 강제 퇴장 하시겠습니까?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>취소</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleKick}
+            className={cn('bg-destructive hover:bg-destructive/90')}
+          >
+            확인
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default KickDialog;

--- a/fe/src/pages/GamePage/PlayerList/Player.tsx
+++ b/fe/src/pages/GamePage/PlayerList/Player.tsx
@@ -7,7 +7,7 @@ import useRoomStore from '@/stores/zustand/useRoomStore';
 import { Button } from '@/components/ui/button';
 import { useState } from 'react';
 import { signalingSocket } from '@/services/signalingSocket';
-import { gameSocket } from '@/services/gameSocket';
+import KickDialog from '../GameDialog/KickDialog';
 
 const Player = ({ playerNickname, isReady }: PlayerProps) => {
   const { currentRoom, currentPlayer } = useRoomStore();
@@ -15,9 +15,10 @@ const Player = ({ playerNickname, isReady }: PlayerProps) => {
   const isPlayerHost = isHost(playerNickname);
   const isCurrentPlayer = currentPlayer === playerNickname;
   const [isMuted, setIsMuted] = useState(false);
+  const [showKickDialog, setShowKickDialog] = useState(false);
 
-  const handleKick = async () => {
-    gameSocket.kickPlayer(playerNickname);
+  const handleKick = () => {
+    setShowKickDialog(true);
   };
 
   const handleMuteToggle = () => {
@@ -77,6 +78,12 @@ const Player = ({ playerNickname, isReady }: PlayerProps) => {
           )}
         </div>
       </CardContent>
+
+      <KickDialog
+        open={showKickDialog}
+        onOpenChange={setShowKickDialog}
+        playerNickname={playerNickname}
+      />
     </Card>
   );
 };

--- a/fe/src/pages/GamePage/PlayerList/Player.tsx
+++ b/fe/src/pages/GamePage/PlayerList/Player.tsx
@@ -7,6 +7,7 @@ import useRoomStore from '@/stores/zustand/useRoomStore';
 import { Button } from '@/components/ui/button';
 import { useState } from 'react';
 import { signalingSocket } from '@/services/signalingSocket';
+import { gameSocket } from '@/services/gameSocket';
 
 const Player = ({ playerNickname, isReady }: PlayerProps) => {
   const { currentRoom, currentPlayer } = useRoomStore();
@@ -15,9 +16,8 @@ const Player = ({ playerNickname, isReady }: PlayerProps) => {
   const isCurrentPlayer = currentPlayer === playerNickname;
   const [isMuted, setIsMuted] = useState(false);
 
-  const handleKick = () => {
-    // TODO: 강퇴 로직 구현
-    console.log(`강퇴: ${playerNickname}`);
+  const handleKick = async () => {
+    gameSocket.kickPlayer(playerNickname);
   };
 
   const handleMuteToggle = () => {

--- a/fe/src/pages/GamePage/index.tsx
+++ b/fe/src/pages/GamePage/index.tsx
@@ -9,15 +9,17 @@ import { NotFound } from '@/components/common/NotFound';
 import GameScreen from './GameScreen/GameScreen';
 import { useAudioManager } from '@/hooks/useAudioManager';
 import { signalingSocket } from '@/services/signalingSocket';
+import { toast } from 'react-toastify';
 
 const GamePage = () => {
   const [showExitDialog, setShowExitDialog] = useState(false);
-  const { currentRoom } = useRoomStore();
+  const { currentRoom, kickedPlayer, setKickedPlayer } = useRoomStore();
   const audioManager = useAudioManager();
 
   useReconnect({ currentRoom });
   useBackExit({ setShowExitDialog });
 
+  // 오디오 매니저 설정
   useEffect(() => {
     signalingSocket.setAudioManager(audioManager);
 
@@ -25,6 +27,18 @@ const GamePage = () => {
       signalingSocket.setAudioManager(null);
     };
   }, [audioManager]);
+
+  // 강퇴 알림 처리 추가
+  useEffect(() => {
+    if (kickedPlayer) {
+      toast.error(`${kickedPlayer}님이 강퇴되었습니다.`, {
+        position: 'bottom-right',
+        autoClose: 2000,
+      });
+
+      setKickedPlayer(null);
+    }
+  }, [kickedPlayer, setKickedPlayer, toast]);
 
   const handleClickExit = () => {
     setShowExitDialog(true);

--- a/fe/src/pages/GamePage/index.tsx
+++ b/fe/src/pages/GamePage/index.tsx
@@ -34,6 +34,9 @@ const GamePage = () => {
       toast.error(`${kickedPlayer}님이 강퇴되었습니다.`, {
         position: 'bottom-right',
         autoClose: 2000,
+        style: {
+          fontFamily: 'Galmuri11, monospace',
+        },
       });
 
       setKickedPlayer(null);

--- a/fe/src/services/gameSocket.ts
+++ b/fe/src/services/gameSocket.ts
@@ -58,6 +58,27 @@ class GameSocket extends SocketService {
         });
       }
     });
+
+    this.socket.on('kicked', (playerNickname: string) => {
+      const {
+        currentRoom,
+        currentPlayer,
+        setCurrentRoom,
+        setCurrentPlayer,
+        setKickedPlayer,
+      } = useRoomStore.getState();
+
+      if (!currentRoom) return;
+
+      if (currentPlayer === playerNickname) {
+        setCurrentRoom(null);
+        setCurrentPlayer(null);
+        window.location.href = '/';
+        return;
+      }
+
+      setKickedPlayer(playerNickname);
+    });
   }
 
   createRoom(roomName: string, hostNickname: string) {
@@ -66,6 +87,10 @@ class GameSocket extends SocketService {
 
   joinRoom(roomId: string, playerNickname: string) {
     this.socket?.emit('joinRoom', { roomId, playerNickname });
+  }
+
+  kickPlayer(playerNickname: string) {
+    this.socket?.emit('kickPlayer', playerNickname);
   }
 }
 

--- a/fe/src/services/signalingSocket.ts
+++ b/fe/src/services/signalingSocket.ts
@@ -55,7 +55,6 @@ class SignalingSocket extends SocketService {
       // console.log('[WebRTCClient] 방 정보 수신:', roomInfo);
       const { setUserMappings } = usePeerStore.getState();
 
-      console.log(roomInfo);
       setUserMappings(roomInfo.userMappings);
 
       this.handleRoomInfo();
@@ -379,35 +378,11 @@ class SignalingSocket extends SocketService {
    */
   private handleRemoteStream(stream: MediaStream, peerId: string) {
     // console.log('[WebRTCClient] 원격 스트림 처리:', peerId);
-    console.log('1. Remote Stream 수신:', {
-      peerId,
-      streamActive: stream.active,
-      audioTracks: stream.getAudioTracks().length,
-    });
 
     const audioManager = this.audioManager;
-    console.log('2. audioManager 상태:', {
-      exists: !!audioManager,
-    });
 
     if (audioManager) {
-      try {
-        console.log('3. 오디오 스트림 설정 시작');
-        audioManager.setAudioStream(peerId, stream);
-        console.log('4. 오디오 스트림 설정 완료');
-
-        // 오디오 엘리먼트 생성 확인
-        setTimeout(() => {
-          const audioElement = document.getElementById(`audio-${peerId}`);
-          console.log('5. 생성된 오디오 엘리먼트 확인:', {
-            exists: !!audioElement,
-            srcObject: !!(audioElement as HTMLAudioElement)?.srcObject,
-            volume: (audioElement as HTMLAudioElement)?.volume,
-          });
-        }, 100);
-      } catch (error) {
-        console.error('오디오 스트림 설정 실패:', error);
-      }
+      audioManager.setAudioStream(peerId, stream);
     } else {
       console.error('audioManager가 설정되지 않음');
     }

--- a/fe/src/stores/zustand/useRoomStore.ts
+++ b/fe/src/stores/zustand/useRoomStore.ts
@@ -6,18 +6,21 @@ interface RoomStore {
   rooms: Room[];
   currentRoom: Room | null;
   currentPlayer: string | null;
+  kickedPlayer: string | null;
 }
 
 interface RoomActions {
   setRooms: (rooms: Room[]) => void;
   setCurrentRoom: (room: Room) => void;
   setCurrentPlayer: (nickname: string) => void;
+  setKickedPlayer: (nickname: string) => void;
 }
 
 const initialState: RoomStore = {
   rooms: [],
   currentRoom: null,
   currentPlayer: null,
+  kickedPlayer: null,
 };
 
 const useRoomStore = create<RoomStore & RoomActions>()(
@@ -37,6 +40,11 @@ const useRoomStore = create<RoomStore & RoomActions>()(
     setCurrentPlayer: (nickname) =>
       set(() => ({
         currentPlayer: nickname,
+      })),
+
+    setKickedPlayer: (nickname) =>
+      set(() => ({
+        kickedPlayer: nickname,
       })),
   }))
 );


### PR DESCRIPTION
## #️⃣ 이슈 번호
#117

<br>

## 📝 작업
- KickDialog 컴포넌트 생성
- 강제 퇴장 기능 구현
- react-toastify 사용하여 강제 퇴장 토스트 메시지 띄우기

<br>

## 📒 작업 내용
- react-toastify 설치 및 ToastContainer App.tsx 추가
- 강퇴 관련 타입, 상태, 이벤트 설정
- 강퇴 버튼을 클릭하면 KickDialog 띄우기
- KickDialog에서 확인 버튼을 클릭하면 강제 퇴장당하는 사용자는 방 목록 페이지로 이동하고, 남아 있는 사용자들에게 토스트 메시지 보여주기

<br>

## 📺 동작 화면
![kick-player](https://github.com/user-attachments/assets/89592326-cbb2-4fa8-9490-170c34734f04)

<br>

## 🤔 고민
- 강제 퇴장당하는 사용자에게도 퇴장 사실을 알려줘야 할 것 같은데, 방 목록 페이지로 이동했을 때 띄워줘야 할지..?