### PR TITLE
[FE] 방장은 모든 참가자가 준비 완료가 되면 게임을 시작할 수 있다.

### DIFF
--- a/fe/src/pages/GamePage/GameScreen/GameScreen.tsx
+++ b/fe/src/pages/GamePage/GameScreen/GameScreen.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Gamepad2, CheckCircle2 } from 'lucide-react';
 import useRoomStore from '@/stores/zustand/useRoomStore';
+import { gameSocket } from '@/services/gameSocket';
 
 const GameScreen = () => {
   const [isReady, setIsReady] = useState(false);
@@ -20,21 +21,22 @@ const GameScreen = () => {
 
   const isHost = currentPlayer === currentRoom.hostNickname;
 
-  // 방장을 제외한 나머지 플레이어들의 준비 상태 체크
   const allPlayersReady = currentRoom.players
-    .slice(1) // 첫 번째 플레이어(방장)를 제외
+    .slice(1)
     .every((player) => player.isReady);
 
-  const handleReady = () => {
-    setIsReady(true);
-    // TODO: 서버에 준비 상태 전송 로직 추가 필요
+  const toggleReady = () => {
+    const newReadyState = !isReady;
+    setIsReady(newReadyState);
+
+    gameSocket.setReady();
   };
 
   const handleGameStart = () => {
-    // TODO: 게임 시작 로직 추가 필요
+    // TODO: 게임 시작 후 화면 중앙 버튼 display: none
+    gameSocket.startGame();
   };
 
-  // 방장인지 아닌지로 버튼 분기
   return (
     <div className="h-[27rem] bg-muted rounded-lg flex flex-col items-center justify-center space-y-4">
       {isHost ? (
@@ -50,16 +52,15 @@ const GameScreen = () => {
       ) : (
         <Button
           size="lg"
-          disabled={isReady}
-          onClick={handleReady}
-          className={`font-galmuri px-8 py-6 text-lg ${isReady ? 'bg-green-500 hover:bg-green-500' : ''}`}
+          onClick={toggleReady}
+          className={`font-galmuri px-8 py-6 text-lg ${isReady ? 'bg-cyan-500 hover:bg-cyan-500' : ''}`}
         >
           <CheckCircle2 className="mr-2 h-5 w-5" />
           {isReady ? '준비 완료' : '게임 준비'}
         </Button>
       )}
 
-      {isHost && !allPlayersReady && (
+      {!allPlayersReady && (
         <p className="font-galmuri text-sm text-muted-foreground mt-2">
           모든 플레이어가 준비를 완료해야 게임을 시작할 수 있습니다.
         </p>

--- a/fe/src/pages/GamePage/PlayerList/Player.tsx
+++ b/fe/src/pages/GamePage/PlayerList/Player.tsx
@@ -38,12 +38,11 @@ const Player = ({ playerNickname, isReady }: PlayerProps) => {
   };
 
   return (
-    <Card className="h-full">
+    <Card className={`h-full ${isReady ? 'bg-cyan-50' : ''}`}>
       <CardContent className="flex h-[4.7rem] items-center justify-between p-4">
         <div className="flex items-center gap-2">
           {isPlayerHost ? <FaCrown className="text-yellow-500" /> : ''}
           <span className="font-galmuri">{playerNickname}</span>
-          {isReady && <span className="text-sm text-green-500">준비 완료</span>}
         </div>
         <div className="flex items-center gap-4">
           {isCurrentPlayer ? (
@@ -54,13 +53,13 @@ const Player = ({ playerNickname, isReady }: PlayerProps) => {
               className={`rounded-full border ${
                 isMuted
                   ? 'border-destructive text-destructive'
-                  : 'border-green-500 text-green-500'
+                  : 'border-cyan-500 text-cyan-500'
               } hover:bg-transparent`}
             >
               {isMuted ? (
                 <FaMicrophoneSlash className="h-5 w-5 text-destructive" />
               ) : (
-                <FaMicrophone className="h-5 w-5 text-green-500" />
+                <FaMicrophone className="h-5 w-5 text-cyan-500" />
               )}
             </Button>
           ) : (

--- a/fe/src/pages/GamePage/index.tsx
+++ b/fe/src/pages/GamePage/index.tsx
@@ -58,7 +58,7 @@ const GamePage = () => {
         <PlayerList
           players={currentRoom.players.map((player) => ({
             playerNickname: player.playerNickname,
-            isReady: false,
+            isReady: player.isReady,
           }))}
         />
       </div>

--- a/fe/src/services/gameSocket.ts
+++ b/fe/src/services/gameSocket.ts
@@ -2,6 +2,7 @@ import { io, Socket } from 'socket.io-client';
 import {
   ClientToServerEvents,
   ServerToClientEvents,
+  TurnData,
 } from '@/types/socketTypes';
 import { PlayerProps, Room } from '@/types/roomTypes';
 import { SocketService } from './SocketService';
@@ -79,6 +80,10 @@ class GameSocket extends SocketService {
 
       setKickedPlayer(playerNickname);
     });
+
+    this.socket.on('turnChanged', (turnData: TurnData) => {
+      console.log(turnData);
+    });
   }
 
   createRoom(roomName: string, hostNickname: string) {
@@ -91,6 +96,14 @@ class GameSocket extends SocketService {
 
   kickPlayer(playerNickname: string) {
     this.socket?.emit('kickPlayer', playerNickname);
+  }
+
+  setReady() {
+    this.socket?.emit('setReady');
+  }
+
+  startGame() {
+    this.socket?.emit('startGame');
   }
 }
 

--- a/fe/src/types/socketTypes.ts
+++ b/fe/src/types/socketTypes.ts
@@ -11,3 +11,11 @@ export interface ClientToServerEvents {
   createRoom: (data: { roomName: string; hostNickname: string }) => void;
   joinRoom: (data: { roomId: string; playerNickname: string }) => void;
 }
+
+export interface TurnData {
+  roomId: string;
+  playerNickname: string;
+  gameMode: string;
+  timeLimit: number;
+  lyrics: string;
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호
#130

<br>

## 📝 작업
- setReady, startGame 이벤트 발행
- 게임 준비 <-> 준비 완료 버튼 토글 되도록 변경
- 게임 시작 버튼 클릭하면 게임 진행을 위한 turnData 받아오기

<br>

## 📒 작업 내용
- 준비 완료된 참가자 Player 컴포넌트 배경색 변경
- 모든 참가자가 준비 완료되었을 때 방장의 게임 시작 버튼 활성화

<br>

## 📺 동작 화면
![ready-and-start](https://github.com/user-attachments/assets/3bcf2902-de55-4271-83b1-468d9ff07e49)

<br>

## 💣 문제
- 방을 생성하여 들어온 방장은 게임 시작 버튼이 활성화 되는 상태
- GameScreen에서 해당 버튼 활성화/비활성화는 방장을 제외한 players의 배열을 가지고 disabled 시키고 있기 때문
- 방장 혼자 있을 때는 빈 배열이 되기 때문에 비활성화가 안 됨 -> 상태로 관리해야 할 것 같음