### PR TITLE
[FE] 음성 처리 소켓 구현

### DIFF
--- a/fe/README.md
+++ b/fe/README.md
@@ -73,8 +73,15 @@
     };
     ```
 
-### Voice Server Error: Invalid session
+### Voice Server Error: Invalid session? 비동기 문제
 
 - 방장이 게임 시작 버튼을 눌렀을 때, 제대로 동작할 때도 있고 이 에러가 뜰 때도 있다.
 - 에러가 뜨고 다시 눌렀을 때 다시 동작할 때도 있고, 계속 안 될 때도 있다.
-- 왜 그러는지 모르겠다..!
+- 왜 그러는지 모르겠다..! -> 비동기 문제😭
+- 로직 순서: gameSocket.startGame -> turnChanged 수신 turnData 상태 저장 -> voiceSocket.startRecording(turnData에 현재 차례 사용자 정보 있음) 그런데 startRecording은 비동기 함수,,
+- 원인: gameSocket.startGame으로 수신하는 turnData가 상태로 저장되기 전에 voiceSocket.startRecording을 해버렸기 때문
+- 해결
+  - handleGameStart 내에서 startGame, startRecording 둘 다 해버리면 죽어도 해결할 수 없다는 것을 깨달음
+  - startRecording에 await 하면 되겠지 했던 게 잘못된 생각이었다,,
+  - useEffect로 turnData 상태가 변할 때 startRecording을 하도록 바꿨다.
+  - 그리고 isGameStarted라는 flag를 두고 한 명씩 턴이 끝날 때마다 이 flag를 바꿔주면서 차례대로 게임을 진행할 수 있도록 함

--- a/fe/README.md
+++ b/fe/README.md
@@ -73,15 +73,23 @@
     };
     ```
 
-### Voice Server Error: Invalid session? 비동기 문제
+### Voice Socket Error: Invalid session? 비동기 문제
+
+```typescript
+this.socket.on('connect_error', (error) => {
+  console.error('Voice server connection error:', error);
+  reject(error);
+});
+```
 
 - 방장이 게임 시작 버튼을 눌렀을 때, 제대로 동작할 때도 있고 이 에러가 뜰 때도 있다.
 - 에러가 뜨고 다시 눌렀을 때 다시 동작할 때도 있고, 계속 안 될 때도 있다.
 - 왜 그러는지 모르겠다..! -> 비동기 문제😭
-- 로직 순서: gameSocket.startGame -> turnChanged 수신 turnData 상태 저장 -> voiceSocket.startRecording(turnData에 현재 차례 사용자 정보 있음) 그런데 startRecording은 비동기 함수,,
+- 로직 순서: gameSocket.startGame -> turnChanged 수신 turnData 상태 저장 -> voiceSocket.startRecording(turnData에 현재 차례 사용자 정보 있음) 그런데 startRecording은 비동기 함수다..
 - 원인: gameSocket.startGame으로 수신하는 turnData가 상태로 저장되기 전에 voiceSocket.startRecording을 해버렸기 때문
 - 해결
-  - handleGameStart 내에서 startGame, startRecording 둘 다 해버리면 죽어도 해결할 수 없다는 것을 깨달음
-  - startRecording에 await 하면 되겠지 했던 게 잘못된 생각이었다,,
+  - handleGameStart(게임 시작 버튼 클릭 이벤트 핸들러) 내에서 startGame, startRecording 둘 다 해버리면 죽어도 해결할 수 없다는 것을 깨달음
+  - startRecording에 await 하면 되겠지, 했던 게 잘못된 생각이었다. (될 리가 없지! startGame을 awiat 하는 거면 몰라도)
   - useEffect로 turnData 상태가 변할 때 startRecording을 하도록 바꿨다.
   - 그리고 isGameStarted라는 flag를 두고 한 명씩 턴이 끝날 때마다 이 flag를 바꿔주면서 차례대로 게임을 진행할 수 있도록 함
+    - boolean으로 해도 되는 건지 아직 모르겠음.. 일단 급하게 처리

--- a/fe/README.md
+++ b/fe/README.md
@@ -72,3 +72,9 @@
       signalingSocket.setAudioManager(audioManager);
     };
     ```
+
+### Voice Server Error: Invalid session
+
+- 방장이 게임 시작 버튼을 눌렀을 때, 제대로 동작할 때도 있고 이 에러가 뜰 때도 있다.
+- 에러가 뜨고 다시 눌렀을 때 다시 동작할 때도 있고, 계속 안 될 때도 있다.
+- 왜 그러는지 모르겠다..!

--- a/fe/src/hooks/useReconnect.ts
+++ b/fe/src/hooks/useReconnect.ts
@@ -27,7 +27,6 @@ export const useReconnect = ({ currentRoom }) => {
           signalingSocket.connect();
 
           // 3. audioManager 설정 (소켓 연결 후)
-          console.log('Reconnect - audioManager 설정');
           signalingSocket.setAudioManager(audioManager);
 
           // 4. 마이크 권한 요청 및 스트림 설정

--- a/fe/src/hooks/useReconnect.ts
+++ b/fe/src/hooks/useReconnect.ts
@@ -23,8 +23,13 @@ export const useReconnect = ({ currentRoom }) => {
           setCurrentRoom(room);
 
           // 2. 소켓 연결
-          gameSocket.connect();
-          signalingSocket.connect();
+          if (!gameSocket.socket?.connected) {
+            gameSocket.connect();
+          }
+
+          if (!signalingSocket.socket?.connected) {
+            signalingSocket.connect();
+          }
 
           // 3. audioManager 설정 (소켓 연결 후)
           signalingSocket.setAudioManager(audioManager);

--- a/fe/src/pages/GamePage/GameScreen/GameScreen.tsx
+++ b/fe/src/pages/GamePage/GameScreen/GameScreen.tsx
@@ -9,7 +9,7 @@ import useGameStore from '@/stores/zustand/useGameStore';
 
 const GameScreen = () => {
   const [isReady, setIsReady] = useState(false);
-  const [isGameStarted, setIsGameStarted] = useState(true);
+  const [isGameStarted, setIsGameStarted] = useState(false);
   const { currentRoom, currentPlayer, setCurrentPlayer } = useRoomStore();
   const { turnData } = useGameStore();
 
@@ -28,12 +28,7 @@ const GameScreen = () => {
 
   useEffect(() => {
     const startRecording = async () => {
-      if (
-        !turnData ||
-        turnData.playerNickname !== currentPlayer ||
-        !isGameStarted
-      )
-        return;
+      if (!turnData || turnData.playerNickname !== currentPlayer) return;
 
       try {
         console.log('Recording turn for:', turnData);
@@ -50,7 +45,7 @@ const GameScreen = () => {
           console.log(`Voice socket disconnected after ${turnData.timeLimit}s`);
         }, turnData.timeLimit * 1000);
 
-        setIsGameStarted(!isGameStarted);
+        setIsGameStarted((prev) => !prev);
       } catch (error) {
         console.error('Voice recording error:', error);
       }
@@ -79,11 +74,12 @@ const GameScreen = () => {
   };
 
   const handleGameStart = () => {
-    if (!isHost || !isGameStarted) return;
+    if (!isHost || isGameStarted) return;
 
     try {
       console.log('Starting game...');
       gameSocket.startGame();
+      setIsGameStarted((prev) => !prev);
       console.log('Game socket event emitted');
     } catch (error) {
       console.error('Game start error:', error);

--- a/fe/src/pages/GamePage/GameScreen/GameScreen.tsx
+++ b/fe/src/pages/GamePage/GameScreen/GameScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Gamepad2, CheckCircle2 } from 'lucide-react';
 import useRoomStore from '@/stores/zustand/useRoomStore';
@@ -21,9 +21,15 @@ const GameScreen = () => {
 
   const isHost = currentPlayer === currentRoom.hostNickname;
 
-  const allPlayersReady = currentRoom.players
-    .slice(1)
-    .every((player) => player.isReady);
+  const canStartGame = useMemo(() => {
+    if (!currentRoom) return false;
+    if (currentRoom.players.length <= 1) return false;
+
+    return currentRoom.players.every((player) => {
+      const isPlayerHost = player.playerNickname === currentRoom.hostNickname;
+      return isPlayerHost || player.isReady;
+    });
+  }, [currentRoom]);
 
   const toggleReady = () => {
     const newReadyState = !isReady;
@@ -42,7 +48,7 @@ const GameScreen = () => {
       {isHost ? (
         <Button
           size="lg"
-          disabled={!allPlayersReady}
+          disabled={!canStartGame}
           onClick={handleGameStart}
           className="font-galmuri px-8 py-6 text-lg"
         >
@@ -60,7 +66,7 @@ const GameScreen = () => {
         </Button>
       )}
 
-      {!allPlayersReady && (
+      {!canStartGame && (
         <p className="font-galmuri text-sm text-muted-foreground mt-2">
           모든 플레이어가 준비를 완료해야 게임을 시작할 수 있습니다.
         </p>

--- a/fe/src/pages/GamePage/GameScreen/GameScreen.tsx
+++ b/fe/src/pages/GamePage/GameScreen/GameScreen.tsx
@@ -26,8 +26,6 @@ const GameScreen = () => {
     if (turnData && turnData.timeLimit) {
       console.log(`Setting disconnect timer for ${turnData.timeLimit} seconds`);
 
-      console.log(turnData);
-
       const timer = setTimeout(() => {
         voiceSocket.disconnect();
         console.log('Voice socket disconnected after time limit');
@@ -58,18 +56,28 @@ const GameScreen = () => {
     const newReadyState = !isReady;
     setIsReady(newReadyState);
 
-    gameSocket.setReady();
+    if (!isHost) {
+      gameSocket.setReady();
+    }
   };
 
   const handleGameStart = async () => {
-    // TODO: 게임 시작 후 화면 중앙 버튼 display: none
-    gameSocket.startGame();
+    if (!isHost) return;
 
-    await voiceSocket.startRecording(
-      signalingSocket.getLocalStream(),
-      currentRoom.roomId,
-      currentPlayer
-    );
+    try {
+      console.log('Starting game...');
+      gameSocket.startGame();
+      console.log('Game socket event emitted');
+
+      await voiceSocket.startRecording(
+        signalingSocket.getLocalStream(),
+        currentRoom.roomId,
+        currentPlayer
+      );
+      console.log('Voice recording started');
+    } catch (error) {
+      console.error('Game start error:', error);
+    }
   };
 
   return (

--- a/fe/src/pages/GamePage/PlayerList/Player.tsx
+++ b/fe/src/pages/GamePage/PlayerList/Player.tsx
@@ -38,7 +38,7 @@ const Player = ({ playerNickname, isReady }: PlayerProps) => {
   };
 
   return (
-    <Card className={`h-full ${isReady ? 'bg-cyan-50' : ''}`}>
+    <Card className={`h-full ${!isPlayerHost && isReady ? 'bg-cyan-50' : ''}`}>
       <CardContent className="flex h-[4.7rem] items-center justify-between p-4">
         <div className="flex items-center gap-2">
           {isPlayerHost ? <FaCrown className="text-yellow-500" /> : ''}

--- a/fe/src/pages/RoomListPage/RoomList/GameRoom.tsx
+++ b/fe/src/pages/RoomListPage/RoomList/GameRoom.tsx
@@ -9,7 +9,7 @@ interface GameRoomProps {
 
 const GameRoom = ({ room, onJoinRoom }: GameRoomProps) => {
   const isGameStarted = (status: string) => {
-    return status === 'playing';
+    return status === 'progress';
   };
   const isRoomFull = room.players.length >= 4;
 

--- a/fe/src/services/SocketService.ts
+++ b/fe/src/services/SocketService.ts
@@ -10,9 +10,8 @@ export class SocketService {
   get socket(): Socket | undefined {
     return this.#socket;
   }
-
-  setSocket(socket: Socket) {
-    this.#socket = socket;
+  setSocket(socket: Socket | undefined | null) {
+    this.#socket = socket ? socket : undefined;
   }
 
   isConnected() {

--- a/fe/src/services/gameSocket.ts
+++ b/fe/src/services/gameSocket.ts
@@ -87,6 +87,10 @@ class GameSocket extends SocketService {
 
       setTurnData(turnData);
     });
+
+    this.socket.on('voiceProcessingResult', (result) => {
+      console.log(result);
+    });
   }
 
   createRoom(roomName: string, hostNickname: string) {

--- a/fe/src/services/gameSocket.ts
+++ b/fe/src/services/gameSocket.ts
@@ -8,6 +8,7 @@ import { PlayerProps, Room } from '@/types/roomTypes';
 import { SocketService } from './SocketService';
 import useRoomStore from '@/stores/zustand/useRoomStore';
 import { ENV } from '@/config/env';
+import useGameStore from '@/stores/zustand/useGameStore';
 
 class GameSocket extends SocketService {
   constructor() {
@@ -82,7 +83,9 @@ class GameSocket extends SocketService {
     });
 
     this.socket.on('turnChanged', (turnData: TurnData) => {
-      console.log(turnData);
+      const { setTurnData } = useGameStore.getState();
+
+      setTurnData(turnData);
     });
   }
 

--- a/fe/src/services/voiceSocket.ts
+++ b/fe/src/services/voiceSocket.ts
@@ -42,8 +42,6 @@ class VoiceSocket extends SocketService {
         this.setSocket(null);
       }
 
-      console.log('Connecting to voice server:', { roomId, playerNickname });
-
       const socket = io(this.VOICE_SERVER_URL, {
         transports: ['websocket'],
         query: { roomId, playerNickname },
@@ -70,11 +68,6 @@ class VoiceSocket extends SocketService {
       console.error('Voice server error:', error);
       this.handleError(error);
       reject(error);
-    });
-
-    this.socket.on('disconnect', () => {
-      console.log('Voice server disconnected');
-      this.cleanupRecording();
     });
   }
 

--- a/fe/src/services/voiceSocket.ts
+++ b/fe/src/services/voiceSocket.ts
@@ -1,0 +1,174 @@
+import { Socket, io } from 'socket.io-client';
+import { VoiceSocketEvents } from '@/types/socketTypes';
+import { SocketService } from './SocketService';
+
+class VoiceSocket extends SocketService {
+  private mediaRecorder: MediaRecorder | null;
+  private recordingStartTime: number | null;
+  private onSpeechRecognitionResultCallback: ((result: string) => void) | null;
+  private onPitchResultCallback: ((pitch: number) => void) | null;
+  private onErrorCallback: ((error: string) => void) | null;
+  private onRecordingStateChange: ((isRecording: boolean) => void) | null;
+  private audioChunks: BlobPart[];
+  private readonly VOICE_SERVER_URL = 'wss://voice-processing.clovapatra.com';
+
+  constructor() {
+    super();
+    this.mediaRecorder = null;
+    this.recordingStartTime = null;
+    this.onSpeechRecognitionResultCallback = null;
+    this.onPitchResultCallback = null;
+    this.onErrorCallback = null;
+    this.onRecordingStateChange = null;
+    this.audioChunks = [];
+  }
+
+  initialize(
+    onSpeechRecognitionResult: (result: string) => void,
+    onPitchResult: (pitch: number) => void,
+    onError: (error: string) => void,
+    onStateChange: (isRecording: boolean) => void
+  ) {
+    this.onSpeechRecognitionResultCallback = onSpeechRecognitionResult;
+    this.onPitchResultCallback = onPitchResult;
+    this.onErrorCallback = onError;
+    this.onRecordingStateChange = onStateChange;
+  }
+
+  private async connect(roomId: string, playerNickname: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (this.socket?.connected) {
+        this.socket.disconnect();
+        this.setSocket(null);
+      }
+
+      console.log('Connecting to voice server:', { roomId, playerNickname });
+
+      const socket = io(this.VOICE_SERVER_URL, {
+        transports: ['websocket'],
+        query: { roomId, playerNickname },
+      }) as Socket<VoiceSocketEvents>;
+
+      this.setSocket(socket);
+      this.setupEventListeners(resolve, reject);
+    });
+  }
+
+  private setupEventListeners(
+    resolve: () => void,
+    reject: (error: Error) => void
+  ) {
+    if (!this.socket) return;
+
+    this.socket.on('connect', () => {
+      console.log('Voice server connected');
+      this.socket?.emit('start_recording');
+      resolve();
+    });
+
+    this.socket.on('error', (error: Error) => {
+      console.error('Voice server error:', error);
+      this.handleError(error);
+      reject(error);
+    });
+
+    this.socket.on('disconnect', () => {
+      console.log('Voice server disconnected');
+      this.cleanupRecording();
+    });
+  }
+
+  async startRecording(
+    localStream: MediaStream,
+    roomId: string,
+    playerNickname: string
+  ) {
+    try {
+      if (!localStream) {
+        throw new Error('마이크가 연결되어 있지 않습니다.');
+      }
+
+      await this.connect(roomId, playerNickname);
+
+      const audioTrack = localStream.getAudioTracks()[0];
+      const mediaStream = new MediaStream([audioTrack]);
+
+      this.mediaRecorder = new MediaRecorder(mediaStream, {
+        mimeType: 'audio/webm;codecs=opus',
+        bitsPerSecond: 16000,
+      });
+
+      this.mediaRecorder.ondataavailable = async (event: BlobEvent) => {
+        if (event.data.size > 0) {
+          try {
+            const buffer = await event.data.arrayBuffer();
+            if (this.socket?.connected) {
+              console.log('Sending audio chunk:', buffer.byteLength, 'bytes');
+              this.socket.emit('audio_data', buffer);
+            }
+          } catch (error) {
+            console.error('Error processing audio chunk:', error);
+            this.handleError(error as Error);
+          }
+        }
+      };
+
+      this.mediaRecorder.start(200);
+      this.recordingStartTime = Date.now();
+      console.log('Recording started');
+
+      if (this.onRecordingStateChange) {
+        this.onRecordingStateChange(true);
+      }
+    } catch (error) {
+      console.error('Error in startRecording:', error);
+      this.handleError(error as Error);
+    }
+  }
+
+  private handleError(error: Error) {
+    console.error('Voice processor error:', error);
+    if (this.onErrorCallback) {
+      this.onErrorCallback(
+        error.message || '음성 처리 중 오류가 발생했습니다.'
+      );
+    }
+    this.cleanupRecording();
+  }
+
+  private cleanupRecording() {
+    console.log('Cleaning up recording');
+
+    if (this.mediaRecorder?.state !== 'inactive') {
+      this.mediaRecorder?.stop();
+    }
+    this.mediaRecorder = null;
+
+    if (this.socket?.connected) {
+      this.socket.disconnect();
+    }
+
+    this.setSocket(null);
+
+    this.recordingStartTime = null;
+    this.audioChunks = [];
+
+    if (this.onRecordingStateChange) {
+      this.onRecordingStateChange(false);
+    }
+  }
+
+  isRecording() {
+    return this.mediaRecorder && this.mediaRecorder.state === 'recording';
+  }
+
+  isConnected() {
+    return this.socket ? this.socket.connected : false;
+  }
+
+  override disconnect() {
+    this.cleanupRecording();
+  }
+}
+
+export const voiceSocket = new VoiceSocket();

--- a/fe/src/services/voiceSocket.ts
+++ b/fe/src/services/voiceSocket.ts
@@ -88,7 +88,9 @@ class VoiceSocket extends SocketService {
 
       this.mediaRecorder = new MediaRecorder(mediaStream, {
         mimeType: 'audio/webm;codecs=opus',
-        bitsPerSecond: 16000,
+        bitsPerSecond: 128000,
+        audioBitsPerSecond: 96000,
+        videoBitsPerSecond: 0,
       });
 
       this.mediaRecorder.ondataavailable = async (event: BlobEvent) => {
@@ -106,7 +108,7 @@ class VoiceSocket extends SocketService {
         }
       };
 
-      this.mediaRecorder.start(200);
+      this.mediaRecorder.start(100);
       this.recordingStartTime = Date.now();
       console.log('Recording started');
 

--- a/fe/src/stores/zustand/useGameStore.ts
+++ b/fe/src/stores/zustand/useGameStore.ts
@@ -1,0 +1,28 @@
+import { TurnData } from '@/types/socketTypes';
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+interface GameStore {
+  turnData: TurnData | null;
+}
+
+interface GameActions {
+  setTurnData: (turnData: TurnData) => void;
+}
+
+const initialState: GameStore = {
+  turnData: null,
+};
+
+const useGameStore = create<GameStore & GameActions>()(
+  devtools((set) => ({
+    ...initialState,
+
+    setTurnData: (turnData) =>
+      set(() => ({
+        turnData,
+      })),
+  }))
+);
+
+export default useGameStore;

--- a/fe/src/stores/zustand/usePeerStore.ts
+++ b/fe/src/stores/zustand/usePeerStore.ts
@@ -1,4 +1,3 @@
-import { Room } from '@/types/roomTypes';
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 

--- a/fe/src/types/socketTypes.ts
+++ b/fe/src/types/socketTypes.ts
@@ -19,3 +19,10 @@ export interface TurnData {
   timeLimit: number;
   lyrics: string;
 }
+
+// 음성 처리 서버 이벤트 타입
+export interface VoiceSocketEvents {
+  audio_data: (buffer: ArrayBuffer) => void;
+  start_recording: () => void;
+  error: (error: Error) => void;
+}

--- a/fe/src/types/webrtcTypes.ts
+++ b/fe/src/types/webrtcTypes.ts
@@ -1,11 +1,4 @@
-export interface RTCConfig {
-  iceServers: RTCIceServer[];
-  iceTransportPolicy?: RTCIceTransportPolicy;
-  bundlePolicy?: RTCBundlePolicy;
-  rtcpMuxPolicy?: RTCRtcpMuxPolicy;
-  iceCandidatePoolSize?: number;
-}
-
+// 시그널링 서버 이벤트 타입
 export interface SignalingData {
   fromId: string;
   toId: string;
@@ -18,7 +11,6 @@ export interface ConnectionPlan {
   to: string;
 }
 
-// 시그널링 서버 이벤트 타입
 export interface SignalingEvents {
   start_connections: (connections: ConnectionPlan[]) => void;
   start_call: (data: { fromId: string }) => void;
@@ -35,11 +27,4 @@ export interface SignalingEvents {
     candidate: RTCIceCandidateInit;
   }) => void;
   user_disconnected: (userId: string) => void;
-}
-
-// 오디오 관련 타입
-export interface AudioStreamSetup {
-  audioContext: AudioContext;
-  source: MediaStreamAudioSourceNode;
-  gainNode: GainNode;
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호
#132

<br>

## 📝 작업
- 음성 처리 소켓 구현
- 음성 처리 서버에 현재 차례의 사용자 음성 데이터 timeLimit 시간 동안 전송


<br>

## 📒 작업 내용
### 음성 처리 소켓 구현하면서 진행한 기타 작업
- 방장 혼자 게임방에 있을 때 게임 시작 버튼 비활성화 되도록 수정
- GameStore 생성하고 turnData 상태 저장
- 방장 여부 체크해서 setReady, startGame 이벤트 발행 구분하도록

### Voice Socket Error: Invalid session? 비동기 문제

```typescript
this.socket.on('connect_error', (error) => {
  console.error('Voice server connection error:', error);
  reject(error);
});
```

- 방장이 게임 시작 버튼을 눌렀을 때, 제대로 동작할 때도 있고 이 에러가 뜰 때도 있다.
- 에러가 뜨고 다시 눌렀을 때 다시 동작할 때도 있고, 계속 안 될 때도 있다.
- 왜 그러는지 모르겠다..! -> 비동기 문제😭
- 로직 순서: gameSocket.startGame -> turnChanged 수신 turnData 상태 저장 -> voiceSocket.startRecording(turnData에 현재 차례 사용자 정보 있음) 그런데 startRecording은 비동기 함수다..
- 원인: gameSocket.startGame으로 수신하는 turnData가 상태로 저장되기 전에 voiceSocket.startRecording을 해버렸기 때문
- 해결
  - handleGameStart(게임 시작 버튼 클릭 이벤트 핸들러) 내에서 startGame, startRecording 둘 다 해버리면 죽어도 해결할 수 없다는 것을 깨달음
  - startRecording에 await 하면 되겠지, 했던 게 잘못된 생각이었다. (될 리가 없지! startGame을 awiat 하는 거면 몰라도)
  - useEffect로 turnData 상태가 변할 때 startRecording을 하도록 바꿨다.
  - 그리고 isGameStarted라는 flag를 두고 한 명씩 턴이 끝날 때마다 이 flag를 바꿔주면서 차례대로 게임을 진행할 수 있도록 함
    - boolean으로 해도 되는 건지 아직 모르겠음.. 일단 급하게 처리

<br>

## 📺 동작 화면
![voice-socket](https://github.com/user-attachments/assets/424a20ad-7ec8-4e6f-82af-4072f1fb2526)


<br>

## 💣 문제
- 테스트 하면서 발견한 문제: 미디어 타입 변경되면(예: 스피커 <-> 이어폰) voiceSocket 에러 발생