### PR TITLE
[FE] 게임 진행 기능 구현

### DIFF
--- a/fe/index.html
+++ b/fe/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Clovapatra</title>
   </head>
   <body>
     <div id="root"></div>

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -17,6 +17,7 @@
         "axios": "^1.7.7",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "framer-motion": "^11.11.17",
         "lottie-react": "^2.4.0",
         "lucide-react": "^0.454.0",
         "react": "^18.3.1",
@@ -1378,39 +1379,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-toast": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.2.tgz",
-      "integrity": "sha512-Z6pqSzmAP/bFJoqMAston4eSNa+ud44NSZTiZUmUen+IOZ5nBY8kzuU5WDBVyFXPtcW6yUalOHsxM/BP6Sv8ww==",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.0",
-        "@radix-ui/react-collection": "1.1.0",
-        "@radix-ui/react-compose-refs": "1.1.0",
-        "@radix-ui/react-context": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.1",
-        "@radix-ui/react-portal": "1.1.2",
-        "@radix-ui/react-presence": "1.1.1",
-        "@radix-ui/react-primitive": "2.0.0",
-        "@radix-ui/react-use-callback-ref": "1.1.0",
-        "@radix-ui/react-use-controllable-state": "1.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.0",
-        "@radix-ui/react-visually-hidden": "1.1.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
@@ -1500,28 +1468,6 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-visually-hidden": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.0.tgz",
-      "integrity": "sha512-N8MDZqtgCgG5S3aV60INAB475osJousYpZ4cTJ2cFbMpdHS5Y6loLTH8LPtkj2QN0x93J30HT/M3qJXM0+lyeQ==",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.0.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
           "optional": true
         }
       }
@@ -3899,6 +3845,30 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.11.17",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.11.17.tgz",
+      "integrity": "sha512-O8QzvoKiuzI5HSAHbcYuL6xU+ZLXbrH7C8Akaato4JzQbX2ULNeniqC2Vo5eiCtFktX9XsJ+7nUhxcl2E2IjpA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fsevents": {

--- a/fe/package.json
+++ b/fe/package.json
@@ -21,6 +21,7 @@
     "axios": "^1.7.7",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "framer-motion": "^11.11.17",
     "lottie-react": "^2.4.0",
     "lucide-react": "^0.454.0",
     "react": "^18.3.1",

--- a/fe/src/hooks/useReconnect.ts
+++ b/fe/src/hooks/useReconnect.ts
@@ -28,11 +28,14 @@ export const useReconnect = ({ currentRoom }) => {
           }
 
           if (!signalingSocket.socket?.connected) {
+            console.log('Connecting signalingSocket...');
             signalingSocket.connect();
           }
 
           // 3. audioManager 설정 (소켓 연결 후)
-          signalingSocket.setAudioManager(audioManager);
+          if (!signalingSocket.hasAudioManager()) {
+            signalingSocket.setAudioManager(audioManager);
+          }
 
           // 4. 마이크 권한 요청 및 스트림 설정
           const stream = await requestPermission();

--- a/fe/src/pages/GamePage/GameDialog/KickDialog.tsx
+++ b/fe/src/pages/GamePage/GameDialog/KickDialog.tsx
@@ -1,4 +1,3 @@
-// pages/GamePage/PlayerList/KickDialog.tsx
 import {
   AlertDialog,
   AlertDialogAction,

--- a/fe/src/pages/GamePage/GameScreen/GameResult.tsx
+++ b/fe/src/pages/GamePage/GameScreen/GameResult.tsx
@@ -1,0 +1,44 @@
+import useGameStore from '@/stores/zustand/useGameStore';
+import { motion } from 'framer-motion';
+
+const GameResult = () => {
+  const resultData = useGameStore((state) => state.resultData);
+
+  if (!resultData) return null;
+
+  return (
+    <motion.div
+      key="result"
+      initial={{ scale: 0.8, opacity: 0 }}
+      animate={{ scale: 1, opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="absolute inset-0 flex items-center justify-center"
+    >
+      <div className="text-center">
+        <div className="font-galmuri text-5xl font-bold mb-3">
+          {resultData.playerNickname}
+        </div>
+        <motion.div
+          key="bubble"
+          className={`font-galmuri text-7xl font-bold ${
+            resultData.result === 'PASS' ? 'text-cyan-500' : 'text-red-500'
+          }`}
+          initial={{ scale: 1 }}
+          animate={{
+            scale: [1, 1.2, 0.8, 1],
+            opacity: [1, 0.9, 0.9, 1],
+          }}
+          transition={{
+            duration: 1.5,
+            repeat: Infinity,
+            repeatType: 'loop',
+          }}
+        >
+          {resultData.result === 'PASS' ? 'PASS!' : 'FAIL!'}
+        </motion.div>
+      </div>
+    </motion.div>
+  );
+};
+
+export default GameResult;

--- a/fe/src/pages/GamePage/GameScreen/GameScreen.tsx
+++ b/fe/src/pages/GamePage/GameScreen/GameScreen.tsx
@@ -1,16 +1,11 @@
-import { useEffect, useMemo, useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Gamepad2, CheckCircle2 } from 'lucide-react';
-import useRoomStore from '@/stores/zustand/useRoomStore';
-import { gameSocket } from '@/services/gameSocket';
-import { voiceSocket } from '@/services/voiceSocket';
-import { signalingSocket } from '../../../services/signalingSocket';
 import useGameStore from '@/stores/zustand/useGameStore';
+import useRoomStore from '@/stores/zustand/useRoomStore';
+import { useEffect } from 'react';
+import ReadyScreen from './ReadyScreen';
+import PlayScreen from './PlayScreen';
 
 const GameScreen = () => {
-  const [isReady, setIsReady] = useState(false);
-  const [isGameStarted, setIsGameStarted] = useState(false);
-  const { currentRoom, currentPlayer, setCurrentPlayer } = useRoomStore();
+  const { currentPlayer, setCurrentPlayer } = useRoomStore();
   const { turnData } = useGameStore();
 
   useEffect(() => {
@@ -22,100 +17,7 @@ const GameScreen = () => {
     }
   }, [currentPlayer, setCurrentPlayer]);
 
-  if (!currentRoom) return null;
-
-  const isHost = currentPlayer === currentRoom.hostNickname;
-
-  useEffect(() => {
-    const startRecording = async () => {
-      if (!turnData || turnData.playerNickname !== currentPlayer) return;
-
-      try {
-        console.log('Recording turn for:', turnData);
-
-        await voiceSocket.startRecording(
-          signalingSocket.getLocalStream(),
-          currentRoom.roomId,
-          currentPlayer
-        );
-        console.log('Voice recording started');
-
-        setTimeout(() => {
-          voiceSocket.disconnect();
-          console.log(`Voice socket disconnected after ${turnData.timeLimit}s`);
-        }, turnData.timeLimit * 1000);
-
-        setIsGameStarted((prev) => !prev);
-      } catch (error) {
-        console.error('Voice recording error:', error);
-      }
-    };
-
-    startRecording();
-  }, [turnData]);
-
-  const canStartGame = useMemo(() => {
-    if (!currentRoom) return false;
-    if (currentRoom.players.length <= 1) return false;
-
-    return currentRoom.players.every((player) => {
-      const isPlayerHost = player.playerNickname === currentRoom.hostNickname;
-      return isPlayerHost || player.isReady;
-    });
-  }, [currentRoom]);
-
-  const toggleReady = () => {
-    const newReadyState = !isReady;
-    setIsReady(newReadyState);
-
-    if (!isHost) {
-      gameSocket.setReady();
-    }
-  };
-
-  const handleGameStart = () => {
-    if (!isHost || isGameStarted) return;
-
-    try {
-      console.log('Starting game...');
-      gameSocket.startGame();
-      setIsGameStarted((prev) => !prev);
-      console.log('Game socket event emitted');
-    } catch (error) {
-      console.error('Game start error:', error);
-    }
-  };
-
-  return (
-    <div className="h-[27rem] bg-muted rounded-lg flex flex-col items-center justify-center space-y-4">
-      {isHost ? (
-        <Button
-          size="lg"
-          disabled={!canStartGame}
-          onClick={handleGameStart}
-          className="font-galmuri px-8 py-6 text-lg"
-        >
-          <Gamepad2 className="mr-2" />
-          게임 시작
-        </Button>
-      ) : (
-        <Button
-          size="lg"
-          onClick={toggleReady}
-          className={`font-galmuri px-8 py-6 text-lg ${isReady ? 'bg-cyan-500 hover:bg-cyan-500' : ''}`}
-        >
-          <CheckCircle2 className="mr-2 h-5 w-5" />
-          {isReady ? '준비 완료' : '게임 준비'}
-        </Button>
-      )}
-
-      {!canStartGame && (
-        <p className="font-galmuri text-sm text-muted-foreground mt-2">
-          모든 플레이어가 준비를 완료해야 게임을 시작할 수 있습니다.
-        </p>
-      )}
-    </div>
-  );
+  return turnData ? <PlayScreen /> : <ReadyScreen />;
 };
 
 export default GameScreen;

--- a/fe/src/pages/GamePage/GameScreen/Lyric.tsx
+++ b/fe/src/pages/GamePage/GameScreen/Lyric.tsx
@@ -1,0 +1,36 @@
+import { motion, AnimatePresence } from 'framer-motion';
+
+interface LyricProps {
+  text: string;
+  timing: number;
+  isActive: boolean;
+  playerIndex?: number;
+}
+
+const Lyric = ({ text, timing, isActive, playerIndex = 0 }: LyricProps) => {
+  return (
+    <AnimatePresence mode="wait">
+      {isActive && (
+        <div className="absolute inset-0 flex items-center">
+          <motion.div
+            key={`lyric-${playerIndex}`}
+            className="absolute whitespace-nowrap"
+            initial={{ x: '100%' }}
+            animate={{ x: '-100%' }}
+            exit={{ opacity: 0 }}
+            transition={{
+              duration: timing,
+              ease: 'linear',
+              delay: 0,
+              immediate: true,
+            }}
+          >
+            <span className="font-galmuri text-4xl text-primary">{text}</span>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default Lyric;

--- a/fe/src/pages/GamePage/GameScreen/PlayScreen.tsx
+++ b/fe/src/pages/GamePage/GameScreen/PlayScreen.tsx
@@ -1,47 +1,164 @@
-import { useEffect } from 'react';
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 import { voiceSocket } from '@/services/voiceSocket';
 import { signalingSocket } from '@/services/signalingSocket';
 import useRoomStore from '@/stores/zustand/useRoomStore';
 import useGameStore from '@/stores/zustand/useGameStore';
+import Lyric from './Lyric';
+import GameResult from './GameResult';
+import { Loader2 } from 'lucide-react';
+import { gameSocket } from '@/services/gameSocket';
+
+type GamePhase = 'intro' | 'gameplay' | 'grading' | 'result';
 
 const PlayScreen = () => {
   const { currentRoom, currentPlayer } = useRoomStore();
-  const { turnData } = useGameStore();
+  const { setGameResult } = useGameStore();
+  const turnData = useGameStore((state) => state.turnData);
+  const resultData = useGameStore((state) => state.resultData);
+  const [gamePhase, setGamePhase] = useState<GamePhase>('intro');
+  const [timeLeft, setTimeLeft] = useState(0);
 
+  const INTRO_TIME = 2000;
+  const RESULT_TIME = 3000;
+
+  // 턴 데이터 변경 시 게임 초기화
   useEffect(() => {
-    const startRecording = async () => {
-      if (
-        !turnData ||
-        turnData.playerNickname !== currentPlayer ||
-        !currentRoom
-      )
-        return;
+    if (!turnData && !resultData) return;
 
-      try {
-        console.log('Recording turn for:', turnData);
+    setGamePhase('intro');
+    setTimeLeft(turnData.timeLimit);
+    setGameResult(null);
 
-        await voiceSocket.startRecording(
-          signalingSocket.getLocalStream(),
-          currentRoom.roomId,
-          currentPlayer
-        );
-        console.log('Voice recording started');
+    const introTimer = setTimeout(() => {
+      setGamePhase('gameplay');
 
-        setTimeout(() => {
-          voiceSocket.disconnect();
-          console.log(`Voice socket disconnected after ${turnData.timeLimit}s`);
-        }, turnData.timeLimit * 1000);
-      } catch (error) {
-        console.error('Voice recording error:', error);
+      // 현재 플레이어 차례이고 게임 참여 가능한 경우에만 녹음 시작
+      if (currentPlayer === turnData.playerNickname && currentRoom) {
+        voiceSocket
+          .startRecording(
+            signalingSocket.getLocalStream(),
+            currentRoom.roomId,
+            currentPlayer
+          )
+          .catch(console.error);
       }
-    };
+    }, INTRO_TIME);
 
-    startRecording();
-  }, [turnData, currentPlayer, currentRoom]);
+    return () => clearTimeout(introTimer);
+  }, [turnData, currentRoom, currentPlayer]);
+
+  // 타이머 처리
+  useEffect(() => {
+    if (gamePhase !== 'gameplay') return;
+
+    const timer = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          if (currentPlayer === turnData?.playerNickname) {
+            voiceSocket.disconnect();
+          }
+          setGamePhase('grading');
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [gamePhase, currentPlayer, turnData]);
+
+  // 결과 처리
+  useEffect(() => {
+    if (!resultData || (gamePhase !== 'grading' && gamePhase !== 'result'))
+      return;
+
+    // grading 페이즈에서만 result로 전환
+    if (gamePhase === 'grading') {
+      console.log('결과 수신, result 화면으로 전환');
+      setGamePhase('result');
+    }
+
+    // result 페이즈에서 타이머 시작
+    if (gamePhase === 'result') {
+      console.log('결과 화면 타이머 시작');
+      const resultTimer = setTimeout(() => {
+        console.log('3초 경과, 다음 턴 호출');
+        gameSocket.next();
+        setGameResult(null);
+      }, RESULT_TIME);
+
+      return () => {
+        console.log('결과 처리 cleanup');
+        clearTimeout(resultTimer);
+      };
+    }
+  }, [resultData, gamePhase, setGameResult]);
+
+  // 디버깅용 phase 변경 로그
+  useEffect(() => {
+    console.log('현재 게임 페이즈:', gamePhase);
+  }, [gamePhase]);
+
+  if (!turnData) return;
 
   return (
-    <div className="h-[27rem] bg-muted rounded-lg flex items-center justify-center">
-      {/* PlayScreen UI */}
+    <div className="relative h-[27rem] bg-muted rounded-lg overflow-hidden">
+      <AnimatePresence mode="wait">
+        {gamePhase === 'intro' && (
+          <motion.div
+            key="intro"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="absolute inset-0 flex flex-col items-center justify-center"
+          >
+            <div className="font-galmuri text-4xl font-bold mb-2">
+              현재 차례 : {turnData.playerNickname}
+            </div>
+            <div className="font-galmuri text-2xl">
+              {turnData.gameMode === 'CLEOPATRA' ? '클레오파트라' : '발음 미션'}
+            </div>
+          </motion.div>
+        )}
+
+        {gamePhase === 'gameplay' && (
+          <div key="gameplay" className="relative h-full">
+            <div className="font-galmuri absolute top-4 right-4 text-2xl font-bold">
+              {timeLeft}초
+            </div>
+            <Lyric
+              text={turnData.lyrics}
+              timing={turnData.timeLimit}
+              isActive={true}
+            />
+          </div>
+        )}
+
+        {gamePhase === 'grading' && (
+          <motion.div
+            key="grading"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="absolute inset-0 flex flex-col items-center justify-center"
+          >
+            <Loader2 className="h-12 w-12 animate-spin mb-4" />
+            <div className="font-galmuri text-2xl">채점 중...</div>
+          </motion.div>
+        )}
+
+        {gamePhase === 'result' && (
+          <motion.div
+            key="result"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <GameResult />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 };

--- a/fe/src/pages/GamePage/GameScreen/PlayScreen.tsx
+++ b/fe/src/pages/GamePage/GameScreen/PlayScreen.tsx
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+import { voiceSocket } from '@/services/voiceSocket';
+import { signalingSocket } from '@/services/signalingSocket';
+import useRoomStore from '@/stores/zustand/useRoomStore';
+import useGameStore from '@/stores/zustand/useGameStore';
+
+const PlayScreen = () => {
+  const { currentRoom, currentPlayer } = useRoomStore();
+  const { turnData } = useGameStore();
+
+  useEffect(() => {
+    const startRecording = async () => {
+      if (
+        !turnData ||
+        turnData.playerNickname !== currentPlayer ||
+        !currentRoom
+      )
+        return;
+
+      try {
+        console.log('Recording turn for:', turnData);
+
+        await voiceSocket.startRecording(
+          signalingSocket.getLocalStream(),
+          currentRoom.roomId,
+          currentPlayer
+        );
+        console.log('Voice recording started');
+
+        setTimeout(() => {
+          voiceSocket.disconnect();
+          console.log(`Voice socket disconnected after ${turnData.timeLimit}s`);
+        }, turnData.timeLimit * 1000);
+      } catch (error) {
+        console.error('Voice recording error:', error);
+      }
+    };
+
+    startRecording();
+  }, [turnData, currentPlayer, currentRoom]);
+
+  return (
+    <div className="h-[27rem] bg-muted rounded-lg flex items-center justify-center">
+      {/* PlayScreen UI */}
+    </div>
+  );
+};
+
+export default PlayScreen;

--- a/fe/src/pages/GamePage/GameScreen/ReadyScreen.tsx
+++ b/fe/src/pages/GamePage/GameScreen/ReadyScreen.tsx
@@ -1,0 +1,80 @@
+import { useState, useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { Gamepad2, CheckCircle2 } from 'lucide-react';
+import useRoomStore from '@/stores/zustand/useRoomStore';
+import { gameSocket } from '@/services/gameSocket';
+
+const ReadyScreen = () => {
+  const [isReady, setIsReady] = useState(false);
+  const [isGameStarted, setIsGameStarted] = useState(false);
+  const { currentRoom, currentPlayer } = useRoomStore();
+
+  if (!currentRoom) return null;
+
+  const isHost = currentPlayer === currentRoom.hostNickname;
+
+  const canStartGame = useMemo(() => {
+    if (!currentRoom) return false;
+    if (currentRoom.players.length <= 1) return false;
+
+    return currentRoom.players.every((player) => {
+      const isPlayerHost = player.playerNickname === currentRoom.hostNickname;
+      return isPlayerHost || player.isReady;
+    });
+  }, [currentRoom]);
+
+  const toggleReady = () => {
+    const newReadyState = !isReady;
+    setIsReady(newReadyState);
+
+    if (!isHost) {
+      gameSocket.setReady();
+    }
+  };
+
+  const handleGameStart = () => {
+    if (!isHost || isGameStarted) return;
+
+    try {
+      console.log('Starting game...');
+      gameSocket.startGame();
+      setIsGameStarted((prev) => !prev);
+      console.log('Game socket event emitted');
+    } catch (error) {
+      console.error('Game start error:', error);
+    }
+  };
+
+  return (
+    <div className="h-[27rem] bg-muted rounded-lg flex flex-col items-center justify-center space-y-4">
+      {isHost ? (
+        <Button
+          size="lg"
+          disabled={!canStartGame}
+          onClick={handleGameStart}
+          className="font-galmuri px-8 py-6 text-lg"
+        >
+          <Gamepad2 className="mr-2" />
+          게임 시작
+        </Button>
+      ) : (
+        <Button
+          size="lg"
+          onClick={toggleReady}
+          className={`font-galmuri px-8 py-6 text-lg ${isReady ? 'bg-cyan-500 hover:bg-cyan-500' : ''}`}
+        >
+          <CheckCircle2 className="mr-2 h-5 w-5" />
+          {isReady ? '준비 완료' : '게임 준비'}
+        </Button>
+      )}
+
+      {!canStartGame && (
+        <p className="font-galmuri text-sm text-muted-foreground mt-2">
+          모든 플레이어가 준비를 완료해야 게임을 시작할 수 있습니다.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default ReadyScreen;

--- a/fe/src/pages/RoomListPage/index.tsx
+++ b/fe/src/pages/RoomListPage/index.tsx
@@ -2,11 +2,6 @@ import SearchBar from '@/components/common/SearchBar';
 import RoomHeader from './RoomHeader/RoomHeader';
 import RoomList from './RoomList/RoomList';
 import { useRoomsSSE } from '@/hooks/useRoomsSSE';
-import { getRoomsQuery } from '@/stores/queries/getRoomsQuery';
-import useRoomStore from '@/stores/zustand/useRoomStore';
-import { useEffect } from 'react';
-import { ENV } from '@/config/env';
-import { Room } from '@/types/roomTypes';
 
 const RoomListPage = () => {
   useRoomsSSE();

--- a/fe/src/services/SocketService.ts
+++ b/fe/src/services/SocketService.ts
@@ -10,6 +10,7 @@ export class SocketService {
   get socket(): Socket | undefined {
     return this.#socket;
   }
+
   setSocket(socket: Socket | undefined | null) {
     this.#socket = socket ? socket : undefined;
   }

--- a/fe/src/services/gameSocket.ts
+++ b/fe/src/services/gameSocket.ts
@@ -84,12 +84,12 @@ class GameSocket extends SocketService {
 
     this.socket.on('turnChanged', (turnData: TurnData) => {
       const { setTurnData } = useGameStore.getState();
-
       setTurnData(turnData);
     });
 
     this.socket.on('voiceProcessingResult', (result) => {
-      console.log(result);
+      const { setGameResult } = useGameStore.getState();
+      setGameResult(result);
     });
   }
 
@@ -111,6 +111,11 @@ class GameSocket extends SocketService {
 
   startGame() {
     this.socket?.emit('startGame');
+  }
+
+  next() {
+    console.log('next called');
+    this.socket?.emit('next');
   }
 }
 

--- a/fe/src/services/signalingSocket.ts
+++ b/fe/src/services/signalingSocket.ts
@@ -445,6 +445,10 @@ class SignalingSocket extends SocketService {
     console.log('[WebRTCClient] 연결 종료 완료');
   }
 
+  hasAudioManager() {
+    return this.audioManager !== null;
+  }
+
   getLocalStream() {
     return this.localStream;
   }

--- a/fe/src/services/voiceSocket.ts
+++ b/fe/src/services/voiceSocket.ts
@@ -16,8 +16,6 @@ class VoiceSocket extends SocketService {
   }
 
   initialize(
-    onSpeechRecognitionResult: (result: string) => void,
-    onPitchResult: (pitch: number) => void,
     onError: (error: string) => void,
     onStateChange: (isRecording: boolean) => void
   ) {

--- a/fe/src/services/voiceSocket.ts
+++ b/fe/src/services/voiceSocket.ts
@@ -4,23 +4,15 @@ import { SocketService } from './SocketService';
 
 class VoiceSocket extends SocketService {
   private mediaRecorder: MediaRecorder | null;
-  private recordingStartTime: number | null;
-  private onSpeechRecognitionResultCallback: ((result: string) => void) | null;
-  private onPitchResultCallback: ((pitch: number) => void) | null;
   private onErrorCallback: ((error: string) => void) | null;
   private onRecordingStateChange: ((isRecording: boolean) => void) | null;
-  private audioChunks: BlobPart[];
   private readonly VOICE_SERVER_URL = 'wss://voice-processing.clovapatra.com';
 
   constructor() {
     super();
     this.mediaRecorder = null;
-    this.recordingStartTime = null;
-    this.onSpeechRecognitionResultCallback = null;
-    this.onPitchResultCallback = null;
     this.onErrorCallback = null;
     this.onRecordingStateChange = null;
-    this.audioChunks = [];
   }
 
   initialize(
@@ -29,8 +21,6 @@ class VoiceSocket extends SocketService {
     onError: (error: string) => void,
     onStateChange: (isRecording: boolean) => void
   ) {
-    this.onSpeechRecognitionResultCallback = onSpeechRecognitionResult;
-    this.onPitchResultCallback = onPitchResult;
     this.onErrorCallback = onError;
     this.onRecordingStateChange = onStateChange;
   }
@@ -106,7 +96,6 @@ class VoiceSocket extends SocketService {
       };
 
       this.mediaRecorder.start(100);
-      this.recordingStartTime = Date.now();
       console.log('Recording started');
 
       if (this.onRecordingStateChange) {
@@ -142,9 +131,6 @@ class VoiceSocket extends SocketService {
 
       this.setSocket(null);
     }
-
-    this.recordingStartTime = null;
-    this.audioChunks = [];
 
     if (this.onRecordingStateChange) {
       this.onRecordingStateChange(false);

--- a/fe/src/services/voiceSocket.ts
+++ b/fe/src/services/voiceSocket.ts
@@ -143,6 +143,7 @@ class VoiceSocket extends SocketService {
 
   override disconnect() {
     this.cleanupRecording();
+    super.disconnect();
   }
 }
 

--- a/fe/src/stores/zustand/useGameStore.ts
+++ b/fe/src/stores/zustand/useGameStore.ts
@@ -1,17 +1,23 @@
-import { TurnData } from '@/types/socketTypes';
+import { GameResultProps, TurnData } from '@/types/socketTypes';
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
 interface GameStore {
   turnData: TurnData | null;
+  resultData: GameResultProps;
+  isGameStarted: boolean;
 }
 
 interface GameActions {
   setTurnData: (turnData: TurnData) => void;
+  setGameResult: (resultData: GameResultProps) => void;
+  setIsGameStarted: (isGameStarted: boolean) => void;
 }
 
 const initialState: GameStore = {
   turnData: null,
+  resultData: null,
+  isGameStarted: false,
 };
 
 const useGameStore = create<GameStore & GameActions>()(
@@ -21,6 +27,16 @@ const useGameStore = create<GameStore & GameActions>()(
     setTurnData: (turnData) =>
       set(() => ({
         turnData,
+      })),
+
+    setGameResult: (resultData) =>
+      set(() => ({
+        resultData,
+      })),
+
+    setIsGameStarted: (isGameStarted) =>
+      set(() => ({
+        isGameStarted,
       })),
   }))
 );

--- a/fe/src/types/socketTypes.ts
+++ b/fe/src/types/socketTypes.ts
@@ -5,11 +5,17 @@ export interface ServerToClientEvents {
   roomCreated: (room: Room) => void;
   updateUsers: (players: string[]) => void;
   error: (error: { code: string; message: string }) => void;
+  kicked: (playerNickname: string) => void;
+  turnChanged: (turnData: TurnData) => void;
+  voiceProcessingResult: (result: GameResultProps) => void;
 }
 
 export interface ClientToServerEvents {
   createRoom: (data: { roomName: string; hostNickname: string }) => void;
   joinRoom: (data: { roomId: string; playerNickname: string }) => void;
+  kickPlayer: (playerNickname: string) => void;
+  setReady: () => void;
+  startGame: () => void;
 }
 
 export interface TurnData {
@@ -18,6 +24,11 @@ export interface TurnData {
   gameMode: string;
   timeLimit: number;
   lyrics: string;
+}
+
+export interface GameResultProps {
+  playerNickname: string;
+  result: string;
 }
 
 // 음성 처리 서버 이벤트 타입


### PR DESCRIPTION
## #️⃣ 이슈 번호
#133

<br>

## 📝 작업
- 게임 진행 UI 및 기능 구현

<br>

## 📒 작업 내용
- GameScreen -> ReadyScreen과 PlayScreen으로 분리
  - turnData 여부로 구분하여 GameScreen에서 렌더링
- PlayScreen 게임 페이즈로 렌더링 구분
  - intro: 현재 차례와 게임 모드 알림
  - gameplay: Lyric 컴포넌트와 제한 시간
  - grading: 채점 중
  - result: 게임 결과 GameResult 컴포넌트 PASS or FAIL
- 애니메이션 적용을 위한 framer-motion 설치
- 게임 진행 관련 상태 및 이벤트 추가
- 가사 Lyric 컴포넌트 생성
- 게임 결과 GameResult 컴포넌트 생성

<br>

## 📺 동작 화면
![play-screen-final](https://github.com/user-attachments/assets/07511775-e9d3-497c-b371-aa93812f6d1d)

<br>

## 💣 문제
### 게임 시작했을 때 Timer(제한 시간)와 Lyric(가사)이 등장하는 타이밍이 맞지 않음
- startGame을 이미 했는데 Intro 화면을 2초 보여줘서 그런 건가 싶음
- 게임 시작 버튼 클릭했을 때 Intro 화면을 GameScreen에서 먼저 2초 띄우고, startGame을 하도록 하면 되려나?