### PR TITLE
[FE] 사용자는 키보드 Enter로 Input을 처리할 수 있다.

### DIFF
--- a/fe/README.md
+++ b/fe/README.md
@@ -57,5 +57,19 @@ react-router-dom.js?v=ceca9ee8:4374 ⚠️ React Router Future Flag Warning: Rea
 npm install react@latest react-dom@latest
 ```
 
-업데이트하고 나서 라우팅 문제 생겨서 다운그레이드 함.. 방 나가기 시 나가기 처리가 제대로 안 됨  
+업데이트하고 나서 라우팅 문제 생겨서 다운그레이드함.. 방 나가기 시 나가기 처리가 제대로 안 됨  
 어떻게 해야 하는지 모르겠다ㅜㅜ
+
+### **VolumeBar 스피커 버튼을 토글하여 볼륨 0 ↔ 50으로 조절할 수 있도록 함**
+
+- 진성님이 피드백 주신 부분 반영
+
+### 키보드 Enter로도 동작하도록 함
+
+- Dialog에서 항상 마우스로 Input 필드를 눌러 입력하고, 확인 버튼을 클릭해야만 하는 게 불편했다.
+- 그래서 다음과 같은 것들이 가능하도록 했다.
+  - Dialog Open 시 첫 Input 필드에 포커싱
+  - Input 필드가 여러 개인 경우 Enter로 다음 Input 필드 이동
+  - Enter로 Submit(확인 버튼 클릭과 동일한 동작)
+- shadcn/ui Dialog 컴포넌트는 ESC 키를 눌렀을 때 Dialog Close를 해줘서 이건 따로 처리가 필요 없었다.
+- SearchBar(방 검색)에도 적용할 생각!

--- a/fe/src/hooks/useDialogForm.ts
+++ b/fe/src/hooks/useDialogForm.ts
@@ -1,0 +1,51 @@
+import { useRef, useEffect, KeyboardEvent } from 'react';
+
+interface UseDialogFormProps {
+  inputs: {
+    id: string;
+    value: string;
+    onChange: (value: string) => void;
+  }[];
+  onSubmit: () => void;
+  isSubmitDisabled: boolean;
+}
+
+export const useDialogForm = ({
+  inputs,
+  onSubmit,
+  isSubmitDisabled,
+}: UseDialogFormProps) => {
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+  useEffect(() => {
+    // 첫 번째 입력 필드에 포커스
+    if (inputRefs.current[0]) {
+      inputRefs.current[0].focus();
+    }
+  }, []);
+
+  const handleKeyDown = (
+    event: KeyboardEvent<HTMLInputElement>,
+    index: number
+  ) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+
+      // 마지막 입력 필드가 아닌 경우 다음 필드로 이동
+      if (index < inputs.length - 1) {
+        inputRefs.current[index + 1]?.focus();
+        return;
+      }
+
+      // 마지막 입력 필드이고 제출이 가능한 경우 제출
+      if (!isSubmitDisabled) {
+        onSubmit();
+      }
+    }
+  };
+
+  return {
+    inputRefs,
+    handleKeyDown,
+  };
+};

--- a/fe/src/pages/RoomListPage/RoomDialog/CreateDialog.tsx
+++ b/fe/src/pages/RoomListPage/RoomDialog/CreateDialog.tsx
@@ -10,6 +10,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAudioPermission } from '@/hooks/useAudioPermission';
+import { useDialogForm } from '@/hooks/useDialogForm';
 import { gameSocket } from '@/services/gameSocket';
 import { signalingSocket } from '@/services/signalingSocket';
 import useRoomStore from '@/stores/zustand/useRoomStore';
@@ -22,7 +23,6 @@ const CreateDialog = ({ open, onOpenChange }: RoomDialogProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const [hostNickname, setHostNickname] = useState('');
   const navigate = useNavigate();
-  const currentRoom = useRoomStore((state) => state.currentRoom);
   const setCurrentPlayer = useRoomStore((state) => state.setCurrentPlayer);
   const { requestPermission } = useAudioPermission();
 
@@ -76,6 +76,16 @@ const CreateDialog = ({ open, onOpenChange }: RoomDialogProps) => {
     }
   };
 
+  // 키보드 Enter 동작
+  const { inputRefs, handleKeyDown } = useDialogForm({
+    inputs: [
+      { id: 'roomName', value: roomName, onChange: setRoomName },
+      { id: 'nickname', value: hostNickname, onChange: setHostNickname },
+    ],
+    onSubmit: handleSubmit,
+    isSubmitDisabled: !roomName.trim() || !hostNickname.trim() || isLoading,
+  });
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="font-galmuri sm:max-w-md">
@@ -102,6 +112,8 @@ const CreateDialog = ({ open, onOpenChange }: RoomDialogProps) => {
               placeholder="방 제목을 입력하세요"
               className="col-span-3"
               disabled={isLoading}
+              ref={(el) => (inputRefs.current[0] = el)}
+              onKeyDown={(e) => handleKeyDown(e, 0)}
             />
           </div>
           <div className="space-y-2">
@@ -117,6 +129,8 @@ const CreateDialog = ({ open, onOpenChange }: RoomDialogProps) => {
               placeholder="닉네임을 입력하세요"
               className="col-span-3"
               disabled={isLoading}
+              ref={(el) => (inputRefs.current[1] = el)}
+              onKeyDown={(e) => handleKeyDown(e, 1)}
             />
           </div>
         </div>

--- a/fe/src/pages/RoomListPage/RoomDialog/JoinDialog.tsx
+++ b/fe/src/pages/RoomListPage/RoomDialog/JoinDialog.tsx
@@ -10,6 +10,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAudioPermission } from '@/hooks/useAudioPermission';
+import { useDialogForm } from '@/hooks/useDialogForm';
 import { gameSocket } from '@/services/gameSocket';
 import { signalingSocket } from '@/services/signalingSocket';
 import { getCurrentRoomQuery } from '@/stores/queries/getCurrentRoomQuery';
@@ -27,8 +28,7 @@ const JoinDialog = ({ open, onOpenChange, roomId }: JoinDialogProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
   const { setCurrentRoom } = useRoomStore();
-  const { data: currentRoom, isLoading: isRoomLoading } =
-    getCurrentRoomQuery(roomId);
+  const { data: currentRoom } = getCurrentRoomQuery(roomId);
   const setCurrentPlayer = useRoomStore((state) => state.setCurrentPlayer);
   const { requestPermission } = useAudioPermission();
 
@@ -69,6 +69,19 @@ const JoinDialog = ({ open, onOpenChange, roomId }: JoinDialogProps) => {
     }
   };
 
+  // 키보드 Enter 동작
+  const { inputRefs, handleKeyDown } = useDialogForm({
+    inputs: [
+      {
+        id: 'playerNickname',
+        value: playerNickname,
+        onChange: setPlayerNickname,
+      },
+    ],
+    onSubmit: handleJoin,
+    isSubmitDisabled: !playerNickname.trim() || isLoading,
+  });
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="font-galmuri sm:max-w-md">
@@ -91,6 +104,8 @@ const JoinDialog = ({ open, onOpenChange, roomId }: JoinDialogProps) => {
               placeholder="닉네임을 입력하세요"
               className="col-span-3"
               disabled={isLoading}
+              ref={(el) => (inputRefs.current[0] = el)}
+              onKeyDown={(e) => handleKeyDown(e, 0)}
             />
           </div>
         </div>


### PR DESCRIPTION
## #️⃣ 이슈 번호
#152

<br>

## 📝 작업
- useDialogForm Custom Hook 구현 (Input 필드 간 Enter로 이동 및 제출)

<br>

## 📒 작업 내용
Dialog에서 항상 마우스로 Input 필드를 눌러 입력하고, 확인 버튼을 클릭해야만 하는 게 불편했다.
- 그래서 다음과 같은 것들이 가능하도록 했다.
  - Dialog Open 시 첫 Input 필드에 포커싱
  - Input 필드가 여러 개인 경우 Enter로 다음 Input 필드 이동
  - Enter로 Submit(확인 버튼 클릭과 동일한 동작)
- shadcn/ui Dialog 컴포넌트는 ESC 키를 눌렀을 때 Dialog Close를 해줘서 이건 따로 처리가 필요 없었다.
- SearchBar(방 검색)에도 적용할 생각!

<br>

## 📺 동작 화면
![dialog-keyboard](https://github.com/user-attachments/assets/e6700776-6374-4007-a700-1d1dfdbf8181)
