### PR TITLE
[BE] 음성 처리 서버 발음게임 채점 기준 완화

### DIFF
--- a/be/voiceProcessingServer/src/services/speech-recognition.service.js
+++ b/be/voiceProcessingServer/src/services/speech-recognition.service.js
@@ -10,7 +10,7 @@ class SpeechRecognitionService {
     const params = new URLSearchParams({
       lang: "Kor",
       assessment: "true",
-      utterance: utterance,
+      utterance: utterance.replace(/[ ,.]/g, ""),
       graph: "false",
     }).toString();
 
@@ -26,7 +26,7 @@ class SpeechRecognitionService {
         maxBodyLength: Infinity,
       });
 
-      return response.data.text.replaceAll(" ") === utterance.replaceAll(" ") ? response.data.assessment_score : 0;
+      return response.data.assessment_score;
     } catch (error) {
       this.handleApiError(error);
     }


### PR DESCRIPTION
## #️⃣ 이슈 번호
#176

<br>

## 📝 작업

* 음성 처리 서버 발음게임 채점 기준 완화

<br>

## 📒 작업 내용

* 목표 발음게임 대사와 Clova AI API가 인식한 결과가 다른 경우 0점을 반환하던 로직 삭제
* Clova AI API에 요청보낼 때 ` `, `,`, `.` 제거 후 요청