### PR TITLE
[FE] 강퇴당한 사용자에게 Dialog를 띄운다.

### DIFF
--- a/fe/src/components/common/CustomAlertDialog.tsx
+++ b/fe/src/components/common/CustomAlertDialog.tsx
@@ -1,0 +1,45 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+interface CustomAlertDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  actionText?: string;
+}
+
+const CustomAlertDialog = ({
+  open,
+  onOpenChange,
+  title,
+  description,
+  actionText = '확인',
+}: CustomAlertDialogProps) => {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="font-galmuri sm:max-w-[22rem]">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          {description && (
+            <AlertDialogDescription>{description}</AlertDialogDescription>
+          )}
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogAction className="bg-primary hover:bg-primary/90">
+            {actionText}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default CustomAlertDialog;

--- a/fe/src/pages/RoomListPage/index.tsx
+++ b/fe/src/pages/RoomListPage/index.tsx
@@ -2,15 +2,36 @@ import SearchBar from '@/components/common/SearchBar';
 import RoomHeader from './RoomHeader/RoomHeader';
 import RoomList from './RoomList/RoomList';
 import { useRoomsSSE } from '@/hooks/useRoomsSSE';
+import { useEffect, useState } from 'react';
+import CustomAlertDialog from '@/components/common/CustomAlertDialog';
 
 const RoomListPage = () => {
+  const [showAlert, setShowAlert] = useState(false);
+  const [kickedRoomName, setKickedRoomName] = useState('');
+
   useRoomsSSE();
+
+  useEffect(() => {
+    const kickedRoomName = sessionStorage.getItem('kickedRoomName');
+
+    if (kickedRoomName) {
+      setKickedRoomName(kickedRoomName);
+      setShowAlert(true);
+      sessionStorage.removeItem('kickedRoomName');
+    }
+  }, []);
 
   return (
     <div>
       <RoomHeader />
       <SearchBar />
       <RoomList />
+      <CustomAlertDialog
+        open={showAlert}
+        onOpenChange={setShowAlert}
+        title="알림"
+        description={`${kickedRoomName}방에서 강퇴되었습니다.`}
+      />
     </div>
   );
 };

--- a/fe/src/services/gameSocket.ts
+++ b/fe/src/services/gameSocket.ts
@@ -75,6 +75,8 @@ class GameSocket extends SocketService {
       if (!currentRoom) return;
 
       if (currentPlayer === playerNickname) {
+        sessionStorage.setItem('kickedRoomName', currentRoom.roomName);
+
         setCurrentRoom(null);
         setCurrentPlayer(null);
         window.location.href = '/';


### PR DESCRIPTION
## #️⃣ 이슈 번호
#175

<br>

## 📝 작업
- 재사용 가능한 CustomAlertDialog 컴포넌트 생성
- 강퇴 시 현재 게임방 이름 세션 스토리지 저장 후 강퇴당한 사용자에게 Dialog 띄우기

<br>

## 📒 작업 내용
- CustomAlertDialog는 title, description props에 전달하는 내용만 변경하면 재사용 할 수 있음
- 세션 스토리지에서 roomName 가져와 상태 저장 후, Dialog 띄우고 세션 스토리지에서 제거

<br>

## 📺 동작 화면
![kicked-alert](https://github.com/user-attachments/assets/d3d73b8f-1073-4308-9600-e782f6695502)