### PR TITLE
[FE][hotfix] 랜딩페이지 스크롤바 보이도록

### DIFF
--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -107,6 +107,7 @@ body {
 
 body {
   margin: 0;
+  overflow-y: scroll;
 }
 
 .app {
@@ -120,19 +121,19 @@ body {
 }
 
 @media (min-width: 768px) {
-  .game-wrapper {
+  .game-page {
     height: 100vh;
     overflow: hidden;
   }
 }
 
 @media (max-width: 767px) {
-  .game-wrapper {
+  .game-page {
     height: auto;
     overflow-y: visible;
   }
 
-  body {
+  .game-page body {
     overflow-y: auto;
   }
 }

--- a/fe/src/pages/GamePage/index.tsx
+++ b/fe/src/pages/GamePage/index.tsx
@@ -107,7 +107,7 @@ const GamePage = () => {
   }
 
   return (
-    <div className="game-wrapper">
+    <div className="game-page game-wrapper">
       <div className="relative overflow-y-auto p-6 mt-2 min-h-screen">
         <div className="space-y-6">
           <GameScreen />

--- a/fe/src/pages/RoomListPage/index.tsx
+++ b/fe/src/pages/RoomListPage/index.tsx
@@ -35,7 +35,7 @@ const RoomListPage = () => {
   }, []);
 
   return (
-    <div className="game-wrapper">
+    <div className="game-page game-wrapper">
       <div className="relative overflow-y-auto p-6 mt-2 min-h-screen flex-1">
         <RoomHeader />
         <SearchBar />


### PR DESCRIPTION
## #️⃣ 이슈 번호
#246

<br>

## 📝 작업
- 랜딩 페이지 전체화면에서 스크롤바 보이도록 수정
- 방 목록 페이지 & 게임 페이지 모바일 화면에서만 스크롤바 표시